### PR TITLE
refactor: split bot into cogs and roller helper modules

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+    - uses: actions/setup-node@v6
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
-name: Python Checks
+name: Tests
 
 on: [push]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,7 +18,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pylint
-    - name: Analysing the code with pylint
+    - name: Run tests
       run: |
-        pylint $(git ls-files '*.py')
+        python test.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![pre-commit](https://github.com/freiheit/MvKDiceBot/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/pre-commit.yml)
 [![Python Checks](https://github.com/freiheit/MvKDiceBot/actions/workflows/python.yml/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/python.yml)
+[![Tests](https://github.com/freiheit/MvKDiceBot/actions/workflows/test.yml/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/test.yml)
 [![CodeQL](https://github.com/freiheit/MvKDiceBot/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/github-code-scanning/codeql)
 [![Dependabot Updates](https://github.com/freiheit/MvKDiceBot/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/dependabot/dependabot-updates)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![pre-commit](https://github.com/freiheit/MvKDiceBot/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/pre-commit.yml)
 [![Python Checks](https://github.com/freiheit/MvKDiceBot/actions/workflows/python.yml/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/python.yml)
 [![CodeQL](https://github.com/freiheit/MvKDiceBot/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/github-code-scanning/codeql)
 [![Dependabot Updates](https://github.com/freiheit/MvKDiceBot/actions/workflows/dependabot/dependabot-updates/badge.svg)](https://github.com/freiheit/MvKDiceBot/actions/workflows/dependabot/dependabot-updates)

--- a/helpcog.py
+++ b/helpcog.py
@@ -1,0 +1,80 @@
+#!.venv/bin/python3
+# MvKDiceBot: Discord bot for rolling dice for Mecha Vs Kaiju
+# Copyright (C) 2023  Eric Eisenhart
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Help command for MvKDiceBot, usable as both ?help and /help."""
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+
+class _HelpDestination:  # pylint: disable=too-few-public-methods
+    """Routes help output through a context, ephemerally.
+
+    ``ephemeral=True`` makes ``/help`` visible only to the user who ran it (the
+    "Only you can see this" style). It is silently ignored for the text
+    ``?help`` command, which stays visible to the channel as before.
+    """
+
+    def __init__(self, ctx):
+        self.ctx = ctx
+
+    async def send(self, *args, **kwargs):
+        """Send through the context as an ephemeral reply."""
+        return await self.ctx.send(*args, ephemeral=True, **kwargs)
+
+
+class HybridHelpCommand(commands.DefaultHelpCommand):
+    """Default help command that sends output through the context.
+
+    The built-in help command writes to ``ctx.channel`` directly, which would
+    leave a slash-command interaction unacknowledged. Sending through
+    ``ctx.send`` instead lets the same help command answer both the ``?help``
+    text command and the ``/help`` slash command (see ``Help.help_slash``), and
+    makes the ``/help`` reply ephemeral.
+    """
+
+    def get_destination(self):
+        return _HelpDestination(self.context)
+
+
+class Help(commands.Cog):
+    """Provides the /help slash command (text ?help is bot.help_command)."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @app_commands.command(
+        name="help", description="Show the list of commands and how to use them"
+    )
+    @app_commands.describe(command="Optional command name to show detailed help for")
+    async def help_slash(
+        self, interaction: discord.Interaction, command: str | None = None
+    ):
+        """Slash-command (/help) equivalent of the '?help' text command."""
+        ctx = await commands.Context.from_interaction(interaction)
+        if command:
+            await ctx.send_help(command)
+        else:
+            await ctx.send_help()
+
+
+async def setup(bot):
+    """discord.py extension entry point: install the help command and cog."""
+    bot.help_command = HybridHelpCommand()
+    await bot.add_cog(Help(bot))

--- a/mvkconfig.py
+++ b/mvkconfig.py
@@ -1,0 +1,85 @@
+#!.venv/bin/python3
+# MvKDiceBot: Discord bot for rolling dice for Mecha Vs Kaiju
+# Copyright (C) 2023  Eric Eisenhart
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Configuration loading for MvKDiceBot."""
+
+import logging
+import os
+import warnings
+from configparser import ConfigParser
+
+logger = logging.getLogger(__name__)
+
+
+class ImproperlyConfigured(Exception):
+    """Raised when no usable configuration file can be found."""
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+HOME_DIR = os.path.expanduser("~")
+
+DEFAULT_CONFIG_PATHS = [
+    os.path.join(HOME_DIR, ".mvkdicebot.ini"),
+    os.path.join("/etc/mvkdicebot.ini"),
+    os.path.join(BASE_DIR, "mvkdicebot.ini"),
+    os.path.join("mvkdicebot.ini"),
+]
+
+
+def get_config():
+    """Find and parse our config, configuring logging as a side effect."""
+    config = ConfigParser()
+    config_paths = []
+
+    for path in DEFAULT_CONFIG_PATHS:
+        if os.path.isfile(path):
+            config_paths.append(path)
+            break
+    else:
+        raise ImproperlyConfigured("No configuration file found.")
+
+    config.read(config_paths)
+
+    debug = config["MAIN"].getint("debug", 0)
+
+    if debug >= 3:
+        log_level = logging.DEBUG
+    elif debug >= 2:
+        log_level = logging.INFO
+    elif debug >= 1:
+        log_level = logging.WARNING
+    else:
+        log_level = logging.ERROR
+
+    # Configure the root logger so every module's logger inherits the level.
+    logging.basicConfig(level=log_level)
+    logging.getLogger().setLevel(log_level)
+    warnings.resetwarnings()
+
+    return config
+
+
+def get_primary_guild_ids(config):
+    """Return the optional `primary_guilds` config value as a list of guild IDs.
+
+    "Guild" is the Discord API term for a server. The config value is a
+    comma/whitespace-separated list; an empty/missing value yields an empty list
+    (meaning "sync slash commands globally").
+    """
+    raw_guilds = config["MAIN"].get("primary_guilds", "")
+    return [int(guild_id) for guild_id in raw_guilds.replace(",", " ").split()]

--- a/mvkconfig.py
+++ b/mvkconfig.py
@@ -79,7 +79,16 @@ def get_primary_guild_ids(config):
 
     "Guild" is the Discord API term for a server. The config value is a
     comma/whitespace-separated list; an empty/missing value yields an empty list
-    (meaning "sync slash commands globally").
+    (meaning "sync slash commands globally"). Non-integer tokens are skipped
+    with a warning rather than crashing startup.
     """
     raw_guilds = config["MAIN"].get("primary_guilds", "")
-    return [int(guild_id) for guild_id in raw_guilds.replace(",", " ").split()]
+
+    guild_ids = []
+    for token in raw_guilds.replace(",", " ").split():
+        try:
+            guild_ids.append(int(token))
+        except ValueError:
+            logger.warning("Ignoring invalid primary_guilds entry: %r", token)
+
+    return guild_ids

--- a/mvkdicebot.py
+++ b/mvkdicebot.py
@@ -19,27 +19,27 @@
 """MvKDiceBot: Discord bot for rolling dice for Mecha Vs Kaiju"""
 
 import logging
-import os
-import warnings
-from configparser import ConfigParser
 
 import discord
-from discord import app_commands
 from discord.ext import commands
 
-import mvkroller
+import mvkconfig
 
 __version__ = "1.0.0"
 DESCRIPTION = """A dice rolling bot for MvK
 """
 
-# Module-level logger; level/handlers are configured in get_config().
+# Module-level logger; level/handlers are configured by mvkconfig.get_config().
 logger = logging.getLogger(__name__)
 
+# Cogs (loaded as discord.py extensions in setup_hook). Each module provides the
+# commands and an `async def setup(bot)` entry point.
+EXTENSIONS = ("rollcog", "helpcog")
+
 # Guild IDs to register slash commands in directly, for instant updates instead
-# of waiting on global propagation. Populated from the config's `primary_guilds`
-# in main(); an empty list means "sync globally". Mutated in place (not
-# reassigned) so setup_hook sees the configured value.
+# of waiting on global propagation. Populated from the config in main(); an empty
+# list means "sync globally". Mutated in place (not reassigned) so setup_hook
+# sees the configured value.
 primary_guild_ids = []
 
 intents = discord.Intents.default()
@@ -54,67 +54,21 @@ bot = commands.AutoShardedBot(
 )
 
 
-class _HelpDestination:  # pylint: disable=too-few-public-methods
-    """Routes help output through a context, ephemerally.
-
-    ``ephemeral=True`` makes ``/help`` visible only to the user who ran it (the
-    "Only you can see this" style). It is silently ignored for the text
-    ``?help`` command, which stays visible to the channel as before.
-    """
-
-    def __init__(self, ctx):
-        self.ctx = ctx
-
-    async def send(self, *args, **kwargs):
-        """Send through the context as an ephemeral reply."""
-        return await self.ctx.send(*args, ephemeral=True, **kwargs)
-
-
-class HybridHelpCommand(commands.DefaultHelpCommand):
-    """Default help command that sends output through the context.
-
-    The built-in help command writes to ``ctx.channel`` directly, which would
-    leave a slash-command interaction unacknowledged. Sending through
-    ``ctx.send`` instead lets the same help command answer both the ``?help``
-    text command and the ``/help`` slash command (see ``help_slash``), and makes
-    the ``/help`` reply ephemeral.
-    """
-
-    def get_destination(self):
-        return _HelpDestination(self.context)
-
-
-bot.help_command = HybridHelpCommand()
-
-
-@bot.tree.command(  # pylint: disable=no-member
-    name="help", description="Show the list of commands and how to use them"
-)
-@app_commands.describe(command="Optional command name to show detailed help for")
-async def help_slash(interaction: discord.Interaction, command: str | None = None):
-    """Slash-command (/help) equivalent of the '?help' text command."""
-    ctx = await commands.Context.from_interaction(interaction)
-    if command:
-        await ctx.send_help(command)
-    else:
-        await ctx.send_help()
-
-
 @bot.event
 async def setup_hook():
-    """Register application (slash) commands with Discord on startup.
+    """Load the command cogs and register slash commands with Discord on startup.
 
-    The commands are declared as hybrid/tree commands, so discord.py already has
-    the slash-command definitions in the command tree; syncing tells Discord
-    about them.
-
-    If one or more primary guilds are configured (``primary_guilds`` in the
-    config -- "guild" is the Discord API term for a server), the commands are
-    copied to each of those guilds and synced there, which is instant. Any
-    leftover global commands are then cleared so a guild doesn't show each
-    command twice. Otherwise a global sync is done, which can take up to ~1 hour
-    to propagate the first time.
+    The cogs put their slash-command definitions in the command tree; syncing
+    tells Discord about them. If one or more primary guilds are configured
+    (``primary_guilds`` in the config -- "guild" is the Discord API term for a
+    server), the commands are copied to each of those guilds and synced there,
+    which is instant; any leftover global commands are then cleared so a guild
+    doesn't show each command twice. Otherwise a global sync is done, which can
+    take up to ~1 hour to propagate the first time.
     """
+    for extension in EXTENSIONS:
+        await bot.load_extension(extension)
+
     try:
         if primary_guild_ids:
             for guild_id in primary_guild_ids:
@@ -144,156 +98,10 @@ async def on_ready():
     logger.warning(f"Logged in as {bot.user} (ID {bot.user.id})")
 
 
-async def _do_roll(send, roll_func, dicestr):
-    """Run a roller and send its output (or the error message) via ``send``.
-
-    ``send`` is a coroutine that takes a single string: ``ctx.reply`` for the
-    text/hybrid commands or ``interaction.response.send_message`` for the slash
-    aliases. Re-raises RollError after reporting it so it is still logged.
-    """
-    try:
-        await send(roll_func(dicestr))
-    except mvkroller.RollError as exc:
-        await send(exc.getMessage())
-        raise
-
-
-@bot.hybrid_command(aliases=["r", "R", "roll", "rolldice", "diceroll"])  # pylint: disable=no-member
-@app_commands.describe(
-    dicestr="Dice to roll, e.g. '1d20 2d10 d8 2d6'. Add 'advantage'/'disadvantage' for the d20."
-)
-async def mvkroll(ctx, *, dicestr: str):
-    """Rolls NdN format pool of dice and does MvK rules math for you.
-
-    Usable as the '?roll'/'@MvkDiceBot roll' text command or the '/mvkroll'
-    (alias '/r') slash command.
-
-    Example: '?roll 1d20 2d10 d8 2d6'
-
-    Add 'advantage' to discard lowest d20.
-    Add 'disadvantage' to discard highest d20.
-    Example: '?roll 2d20 2d10 advantage'
-    Example: '?roll 2d20 2d10 disadvantage'
-
-    Ignores anything extra it doesn't understand.
-    """
-    await _do_roll(ctx.reply, mvkroller.mvkroll, dicestr)
-
-
-@bot.hybrid_command(
-    aliases=["p", "d", "D", "P", "pr", "PR", "justroll", "justdice", "plain", "dice"]
-)  # pylint: disable=no-member
-@app_commands.describe(
-    dicestr="Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
-)
-async def plainroll(ctx, *, dicestr: str):
-    """Rolls NdN format pool of dice. Only accepts d20, d12, d10, d8, d6 and d4 dice.
-
-    Usable as the '?p'/'@MvkDiceBot plainroll' text command or the '/plainroll'
-    (alias '/p') slash command.
-
-    For single d20, may call out likely special things like 20=crit, 1=fail, even and odd.
-
-    Accepts multiple +N and -N modifiers.
-
-    Prints a total of all the dice and the modifiers.
-
-    Example: '?justroll 1d20 2d10 d8 2d6 d6' (note: will work out that it's 3d6)
-    Example: '?p 1d20 +5 +2' (note: will add 7 to whatever is rolled)
-
-    Ignores anything extra it doesn't understand.  Doesn't handle
-    advantage/disadvantage, since in many rules and situations an 18 might
-    be better than a 19 or a 2 better than a 16.
-    """
-    await _do_roll(ctx.reply, mvkroller.plainroll, dicestr)
-
-
-# Discord application commands have no alias mechanism, so the short '/r' and
-# '/p' forms are registered as their own slash commands that reuse the rollers.
-@bot.tree.command(  # pylint: disable=no-member
-    name="r", description="Roll a dice pool with MvK rules math (same as /mvkroll)"
-)
-@app_commands.describe(
-    dicestr="Dice to roll, e.g. '1d20 2d10 d8 2d6'. Add 'advantage'/'disadvantage' for the d20."
-)
-async def mvkroll_slash_alias(interaction: discord.Interaction, dicestr: str):
-    """Slash-command alias (/r) for /mvkroll."""
-    await _do_roll(interaction.response.send_message, mvkroller.mvkroll, dicestr)
-
-
-@bot.tree.command(  # pylint: disable=no-member
-    name="p", description="Roll a dice pool and total it (same as /plainroll)"
-)
-@app_commands.describe(
-    dicestr="Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
-)
-async def plainroll_slash_alias(interaction: discord.Interaction, dicestr: str):
-    """Slash-command alias (/p) for /plainroll."""
-    await _do_roll(interaction.response.send_message, mvkroller.plainroll, dicestr)
-
-
-class ImproperlyConfigured(Exception):
-    """Boring Exception Class"""
-
-    # pylint: disable=unnecessary-pass
-    pass
-
-
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-HOME_DIR = os.path.expanduser("~")
-
-DEFAULT_CONFIG_PATHS = [
-    os.path.join(HOME_DIR, ".mvkdicebot.ini"),
-    os.path.join("/etc/mvkdicebot.ini"),
-    os.path.join(BASE_DIR, "mvkdicebot.ini"),
-    os.path.join("mvkdicebot.ini"),
-]
-
-
-def get_config():
-    """Find and parse our config, configuring logging as a side effect."""
-    config = ConfigParser()
-    config_paths = []
-
-    for path in DEFAULT_CONFIG_PATHS:
-        if os.path.isfile(path):
-            config_paths.append(path)
-            break
-    else:
-        raise ImproperlyConfigured("No configuration file found.")
-
-    config.read(config_paths)
-
-    debug = config["MAIN"].getint("debug", 0)
-
-    if debug >= 3:
-        log_level = logging.DEBUG
-    elif debug >= 2:
-        log_level = logging.INFO
-    elif debug >= 1:
-        log_level = logging.WARNING
-    else:
-        log_level = logging.ERROR
-
-    logging.basicConfig(level=log_level)
-    logger.setLevel(log_level)
-    warnings.resetwarnings()
-    logger.addHandler(logging.StreamHandler())
-
-    return config
-
-
 def main():
     """Load configuration and run the bot."""
-    config = get_config()
-
-    # `primary_guilds` is an optional comma/whitespace-separated list of guild
-    # (server) IDs to register slash commands in directly. Mutate the list in
-    # place so setup_hook sees it without needing a global statement.
-    raw_guilds = config["MAIN"].get("primary_guilds", "")
-    primary_guild_ids.extend(
-        int(guild_id) for guild_id in raw_guilds.replace(",", " ").split()
-    )
+    config = mvkconfig.get_config()
+    primary_guild_ids.extend(mvkconfig.get_primary_guild_ids(config))
 
     bot.run(
         token=config["MAIN"].get("authtoken"),

--- a/mvkdicebot.py
+++ b/mvkdicebot.py
@@ -98,6 +98,26 @@ async def on_ready():
     logger.warning(f"Logged in as {bot.user} (ID {bot.user.id})")
 
 
+@bot.tree.error
+async def on_app_command_error(interaction, error):
+    """Log slash-command errors and make sure the interaction gets a reply.
+
+    A slash command acknowledges Discord by responding to the interaction.
+    Without this, an unexpected error (or a too-long response) before that
+    happens leaves the interaction unanswered, which Discord shows the user as
+    "This interaction failed". If the command already replied (e.g. a RollError
+    message), is_done() is true and we only log.
+    """
+    logger.error("Error in application command %s", interaction.command, exc_info=error)
+    if not interaction.response.is_done():
+        try:
+            await interaction.response.send_message(
+                "Sorry, something went wrong running that command.", ephemeral=True
+            )
+        except discord.HTTPException:
+            logger.exception("Failed to send application command error message")
+
+
 def main():
     """Load configuration and run the bot."""
     config = mvkconfig.get_config()

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -17,216 +17,28 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 # https://github.com/freiheit/MvKDiceBot
-"""MvKRoller: Dice roller for the MvKDiceBot"""
+"""MvKRoller: the two top-level dice rollers, mvkroll and plainroll.
 
-import functools
+The supporting helpers live in companion modules: rollcommon (shared parsing,
+rolling, and display), rollmvkhelpers (MvK rules math), and rollplainhelpers
+(plain roll extras). RollError and parse_dice are re-exported here so callers
+can keep using ``mvkroller.RollError`` / ``mvkroller.parse_dice``.
+"""
+
 import logging
-import random
 import re
 
+from rollcommon import RollError, parse_dice, print_dice, roll_dice
+from rollmvkhelpers import (
+    adv_disadv,
+    calc_action,
+    calc_impact,
+    crit_fumble,
+    possible_fumble,
+)
+from rollplainhelpers import parse_math, print_d20_special
+
 logger = logging.getLogger(__name__)
-
-
-class RollError(Exception):
-    """Boring Exception Class"""
-
-    message = ""
-
-    def __init__(self, msg):
-        self.message = msg
-
-    # pylint: disable=invalid-name
-    def getMessage(self):
-        """return this exception's message"""
-        return self.message
-
-
-@functools.cache
-def parse_dice(dicestr: str):
-    """Parses the dice string and returns a dictionary of dieSize->count"""
-    # types of dice we're looking for:
-    dicecounts = {
-        20: 0,
-        12: 0,
-        10: 0,
-        8: 0,
-        6: 0,
-        4: 0,
-    }
-
-    pattern_ndn = re.compile(r"([0-9]*) *[dD]([0-9]+)")
-
-    try:
-        for count, size in re.findall(pattern_ndn, dicestr):
-            logger.debug("Roll count=%s size=%s", count, size)
-            size = int(size)
-            if len(count) >= 1:
-                count = int(count)
-            elif len(count) < 1 or int(count) < 1:
-                count = 1
-            if size in dicecounts:
-                dicecounts[size] += count
-            else:
-                raise RollError(f"Invalid dice size d{size}")
-    except Exception as exc:
-        raise RollError("Exception while parsing dice.") from exc
-
-    return dicecounts
-
-
-def roll_dice(dicecounts):
-    """Returns a dictionary of dieSize => rolls[]"""
-    dicerolls = {
-        20: [],
-        12: [],
-        10: [],
-        8: [],
-        6: [],
-        4: [],
-    }
-
-    try:
-        for size, num in dicecounts.items():
-            if num > 0:
-                dicerolls[size] = [random.randint(1, size) for idx in range(0, num)]
-    except Exception as exc:
-        raise RollError("Exception while rolling dice.") from exc
-
-    return dicerolls
-
-
-def print_dice(dicerolls):
-    "Creates a string rep of the rolled dice"
-    answer = "Dice: "
-    try:
-        for size, values in dicerolls.items():
-            if len(values) > 0:
-                answer += f"{len(values)}d{size}{str(values)} "
-        # answer += "\n"
-    except Exception as exc:
-        raise RollError("Coding error displaying Dice") from exc
-
-    return answer
-
-
-def print_d20_special(dicerolls):
-    """Checks for special d20 rules and adds stuff for any special stuff"""
-    answer = ""
-    try:
-        for size, values in dicerolls.items():
-            if len(values) == 1 and size == 20:
-                if values[0] == 1:
-                    answer += "\n1 is **Crit Fumble/Fail**"
-                elif values[0] == 20:
-                    answer += "\n20 is **Crit Success**"
-                elif values[0] % 2 == 0:
-                    answer += " (_Even_)"
-                else:
-                    answer += " (_Odd_)"
-
-                if values[0] == 2:  # separate because also even
-                    answer += "\n_Two-Weapon Hit?_"
-
-    except Exception as exc:
-        raise RollError("Coding error displaying Dice") from exc
-
-    return answer
-
-
-def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
-    """Perform extra work when rolling with advantage or disadvantage"""
-    answer = ""
-    fortunedicerolls = dicerolls[20]
-
-    try:
-        if advantage or disadvantage:
-            logger.debug("Dicecounts %s", dicecounts)
-            logger.debug("Dicerolls %s", dicerolls)
-            answer += "Original d20s: "
-            answer += f"{len(fortunedicerolls)}d20{str(fortunedicerolls)} -- "
-            if advantage:
-                answer += "_Applying advantage_\n\n"
-                dicerolls[20].sort(reverse=True)
-                logger.debug("Advantage rolls %s", dicerolls[20])
-            if disadvantage:
-                answer += "_Applying disadvantage_\n\n"
-                dicerolls[20].sort()
-                logger.debug("Disadvantage rolls %s", dicerolls[20])
-            dicerolls[20] = [dicerolls[20][0]]
-    except Exception as exc:
-        raise RollError("Coding error calculating advantage or disadvantage.") from exc
-
-    return answer, dicerolls[20]
-
-
-def calc_action(fortunedicerolls, characterdicerolls):
-    """Compute the action total, using up to one d20 and the highest character die roll."""
-    try:
-        action_dice = fortunedicerolls + characterdicerolls
-        action_dice.sort(reverse=True)
-        action_dice = action_dice[:2]
-        answer = f"**Action Total: {str(sum(action_dice))}** {str(action_dice)}\n"
-    except Exception as exc:
-        raise RollError(
-            "Coding error flattening dice rolls and creating total."
-        ) from exc
-    return answer
-
-
-def calc_impact(fortunedicerolls, characterdicerolls):
-    """Calculate the impact total"""
-    try:
-        # die results of 10 or higher on a d10 or 12 give two impact. It doesn't happen on a d20.
-        fortuneimpact = 1 if fortunedicerolls[0] >= 4 else 0
-        doublecharacterimpact = sum(2 for p in characterdicerolls if p >= 10)
-        characterimpact = sum(1 for p in characterdicerolls if 4 <= p < 10)
-        impact = fortuneimpact + doublecharacterimpact + characterimpact
-        impact = max(impact, 1)
-        answer = f"**Impact: {impact}** "
-        answer += (
-            f"(fortune={fortuneimpact} 2x={doublecharacterimpact} 1x={characterimpact})"
-        )
-    except Exception as exc:
-        raise RollError("Coding error calculating Impact") from exc
-    return answer
-
-
-def crit_fumble(fortunedicerolls, characterdicerolls):
-    """Check if we had a critical fumble. If so, add output and discard lowest non-1 die"""
-    answer = ""
-    newdicerolls = characterdicerolls
-    if fortunedicerolls[0] == 1:
-        answer += "**Critical Fumble**\n"
-        characterdicerolls.sort()
-        newdicerolls = []
-        scratched = False
-        for i in characterdicerolls:
-            if scratched:
-                newdicerolls.append(i)
-            elif i == 1:
-                newdicerolls.append(i)
-            else:
-                scratched = True
-                answer += f"*Scratched {i}*\n"
-                # no append because scratching this die
-
-        answer += "**Gain 1 inspiration point**\n"
-        answer += f"New character dice: {newdicerolls}\n"
-    return answer, newdicerolls
-
-
-def possible_fumble(fortunedicerolls):
-    """
-    You also critically fumble if your action is successfully countered
-    and you roll a 1-3 on the d20
-    """
-    answer = ""
-    if fortunedicerolls[0] <= 3:
-        answer += "**Possible Critical Fumble**\n"
-        answer += (
-            "If your action is successfully countered, gain 1 inspiration point.\n"
-        )
-    return answer
 
 
 def mvkroll(dicestr: str):
@@ -296,19 +108,6 @@ def mvkroll(dicestr: str):
     answer += calc_impact(fortunedicerolls, characterdicerolls)
 
     return answer
-
-
-def parse_math(dicestr: str):
-    """Look for +N and -N things to get a total change"""
-
-    pattern_math = re.compile(r"([+-][0-9]+)")
-
-    amount = 0
-
-    for addstr in re.findall(pattern_math, dicestr):
-        amount += int(addstr)
-
-    return amount
 
 
 def plainroll(dicestr: str):

--- a/rollcog.py
+++ b/rollcog.py
@@ -1,0 +1,133 @@
+#!.venv/bin/python3
+# MvKDiceBot: Discord bot for rolling dice for Mecha Vs Kaiju
+# Copyright (C) 2023  Eric Eisenhart
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Dice-rolling commands for MvKDiceBot (text, mention, and slash)."""
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+import mvkroller
+
+# Slash-command parameter descriptions, shared by the hybrid commands and their
+# /r and /p slash aliases so the help text stays identical.
+MVK_DICE_HELP = (
+    "Dice to roll, e.g. '1d20 2d10 d8 2d6'. Add 'advantage'/'disadvantage' for the d20."
+)
+PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
+
+
+async def _do_roll(send, roll_func, dicestr):
+    """Run a roller and send its output (or the error message) via ``send``.
+
+    ``send`` is a coroutine that takes a single string: ``ctx.reply`` for the
+    text/hybrid commands or ``interaction.response.send_message`` for the slash
+    aliases. Re-raises RollError after reporting it so it is still logged.
+    """
+    try:
+        await send(roll_func(dicestr))
+    except mvkroller.RollError as exc:
+        await send(exc.getMessage())
+        raise
+
+
+class Roll(commands.Cog):
+    """MvK dice-rolling commands."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.hybrid_command(aliases=["r", "R", "roll", "rolldice", "diceroll"])
+    @app_commands.describe(dicestr=MVK_DICE_HELP)
+    async def mvkroll(self, ctx, *, dicestr: str):
+        """Rolls NdN format pool of dice and does MvK rules math for you.
+
+        Usable as the '?roll'/'@MvkDiceBot roll' text command or the '/mvkroll'
+        (alias '/r') slash command.
+
+        Example: '?roll 1d20 2d10 d8 2d6'
+
+        Add 'advantage' to discard lowest d20.
+        Add 'disadvantage' to discard highest d20.
+        Example: '?roll 2d20 2d10 advantage'
+        Example: '?roll 2d20 2d10 disadvantage'
+
+        Ignores anything extra it doesn't understand.
+        """
+        await _do_roll(ctx.reply, mvkroller.mvkroll, dicestr)
+
+    @commands.hybrid_command(
+        aliases=[
+            "p",
+            "d",
+            "D",
+            "P",
+            "pr",
+            "PR",
+            "justroll",
+            "justdice",
+            "plain",
+            "dice",
+        ]
+    )
+    @app_commands.describe(dicestr=PLAIN_DICE_HELP)
+    async def plainroll(self, ctx, *, dicestr: str):
+        """Rolls NdN format pool of dice. Only accepts d20, d12, d10, d8, d6 and d4 dice.
+
+        Usable as the '?p'/'@MvkDiceBot plainroll' text command or the '/plainroll'
+        (alias '/p') slash command.
+
+        For single d20, may call out likely special things like 20=crit, 1=fail, even and odd.
+
+        Accepts multiple +N and -N modifiers.
+
+        Prints a total of all the dice and the modifiers.
+
+        Example: '?justroll 1d20 2d10 d8 2d6 d6' (note: will work out that it's 3d6)
+        Example: '?p 1d20 +5 +2' (note: will add 7 to whatever is rolled)
+
+        Ignores anything extra it doesn't understand.  Doesn't handle
+        advantage/disadvantage, since in many rules and situations an 18 might
+        be better than a 19 or a 2 better than a 16.
+        """
+        await _do_roll(ctx.reply, mvkroller.plainroll, dicestr)
+
+    # Discord application commands have no alias mechanism, so the short '/r' and
+    # '/p' forms are registered as their own slash commands that reuse the rollers.
+    @app_commands.command(
+        name="r", description="Roll a dice pool with MvK rules math (same as /mvkroll)"
+    )
+    @app_commands.describe(dicestr=MVK_DICE_HELP)
+    async def mvkroll_slash_alias(self, interaction: discord.Interaction, dicestr: str):
+        """Slash-command alias (/r) for /mvkroll."""
+        await _do_roll(interaction.response.send_message, mvkroller.mvkroll, dicestr)
+
+    @app_commands.command(
+        name="p", description="Roll a dice pool and total it (same as /plainroll)"
+    )
+    @app_commands.describe(dicestr=PLAIN_DICE_HELP)
+    async def plainroll_slash_alias(
+        self, interaction: discord.Interaction, dicestr: str
+    ):
+        """Slash-command alias (/p) for /plainroll."""
+        await _do_roll(interaction.response.send_message, mvkroller.plainroll, dicestr)
+
+
+async def setup(bot):
+    """discord.py extension entry point: register the Roll cog."""
+    await bot.add_cog(Roll(bot))

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -1,0 +1,109 @@
+#!.venv/bin/python3
+# MvKRoller: Dice roller for the MvK Dice Bot
+# Copyright (C) 2023 Eric Eisenhart
+# edited by CJ Holmes
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Common dice helpers shared by both rollers (parsing, rolling, display)."""
+
+import functools
+import logging
+import random
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class RollError(Exception):
+    """Boring Exception Class"""
+
+    message = ""
+
+    def __init__(self, msg):
+        self.message = msg
+
+    # pylint: disable=invalid-name
+    def getMessage(self):
+        """return this exception's message"""
+        return self.message
+
+
+@functools.cache
+def parse_dice(dicestr: str):
+    """Parses the dice string and returns a dictionary of dieSize->count"""
+    # types of dice we're looking for:
+    dicecounts = {
+        20: 0,
+        12: 0,
+        10: 0,
+        8: 0,
+        6: 0,
+        4: 0,
+    }
+
+    pattern_ndn = re.compile(r"([0-9]*) *[dD]([0-9]+)")
+
+    try:
+        for count, size in re.findall(pattern_ndn, dicestr):
+            logger.debug("Roll count=%s size=%s", count, size)
+            size = int(size)
+            if len(count) >= 1:
+                count = int(count)
+            elif len(count) < 1 or int(count) < 1:
+                count = 1
+            if size in dicecounts:
+                dicecounts[size] += count
+            else:
+                raise RollError(f"Invalid dice size d{size}")
+    except Exception as exc:
+        raise RollError("Exception while parsing dice.") from exc
+
+    return dicecounts
+
+
+def roll_dice(dicecounts):
+    """Returns a dictionary of dieSize => rolls[]"""
+    dicerolls = {
+        20: [],
+        12: [],
+        10: [],
+        8: [],
+        6: [],
+        4: [],
+    }
+
+    try:
+        for size, num in dicecounts.items():
+            if num > 0:
+                dicerolls[size] = [random.randint(1, size) for idx in range(0, num)]
+    except Exception as exc:
+        raise RollError("Exception while rolling dice.") from exc
+
+    return dicerolls
+
+
+def print_dice(dicerolls):
+    "Creates a string rep of the rolled dice"
+    answer = "Dice: "
+    try:
+        for size, values in dicerolls.items():
+            if len(values) > 0:
+                answer += f"{len(values)}d{size}{str(values)} "
+        # answer += "\n"
+    except Exception as exc:
+        raise RollError("Coding error displaying Dice") from exc
+
+    return answer

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -19,7 +19,6 @@
 # https://github.com/freiheit/MvKDiceBot
 """Common dice helpers shared by both rollers (parsing, rolling, display)."""
 
-import functools
 import logging
 import random
 import re
@@ -41,7 +40,6 @@ class RollError(Exception):
         return self.message
 
 
-@functools.cache
 def parse_dice(dicestr: str):
     """Parses the dice string and returns a dictionary of dieSize->count"""
     # types of dice we're looking for:

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -72,8 +72,12 @@ def parse_dice(dicestr: str):
     return dicecounts
 
 
-def roll_dice(dicecounts):
-    """Returns a dictionary of dieSize => rolls[]"""
+def roll_dice(dicecounts, rand_source=None):
+    """Returns a dictionary of dieSize => rolls[]
+
+    A `rand_source` (a random.Random instance) may be supplied so tests can roll
+    deterministically; by default a fresh random.Random() is used.
+    """
     dicerolls = {
         20: [],
         12: [],
@@ -83,10 +87,16 @@ def roll_dice(dicecounts):
         4: [],
     }
 
+    def rollit(size, src):
+        return int(src.random() * size) + 1
+
     try:
+        if rand_source is None:
+            rand_source = random.Random()
+
         for size, num in dicecounts.items():
             if num > 0:
-                dicerolls[size] = [random.randint(1, size) for idx in range(0, num)]
+                dicerolls[size] = [rollit(size, rand_source) for idx in range(0, num)]
     except Exception as exc:
         raise RollError("Exception while rolling dice.") from exc
 

--- a/rollmvkhelpers.py
+++ b/rollmvkhelpers.py
@@ -1,0 +1,122 @@
+#!.venv/bin/python3
+# MvKRoller: Dice roller for the MvK Dice Bot
+# Copyright (C) 2023 Eric Eisenhart
+# edited by CJ Holmes
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Helpers specific to the MvK ruleset roller (mvkroll)."""
+
+import logging
+
+from rollcommon import RollError
+
+logger = logging.getLogger(__name__)
+
+
+def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
+    """Perform extra work when rolling with advantage or disadvantage"""
+    answer = ""
+    fortunedicerolls = dicerolls[20]
+
+    try:
+        if advantage or disadvantage:
+            logger.debug("Dicecounts %s", dicecounts)
+            logger.debug("Dicerolls %s", dicerolls)
+            answer += "Original d20s: "
+            answer += f"{len(fortunedicerolls)}d20{str(fortunedicerolls)} -- "
+            if advantage:
+                answer += "_Applying advantage_\n\n"
+                dicerolls[20].sort(reverse=True)
+                logger.debug("Advantage rolls %s", dicerolls[20])
+            if disadvantage:
+                answer += "_Applying disadvantage_\n\n"
+                dicerolls[20].sort()
+                logger.debug("Disadvantage rolls %s", dicerolls[20])
+            dicerolls[20] = [dicerolls[20][0]]
+    except Exception as exc:
+        raise RollError("Coding error calculating advantage or disadvantage.") from exc
+
+    return answer, dicerolls[20]
+
+
+def calc_action(fortunedicerolls, characterdicerolls):
+    """Compute the action total, using up to one d20 and the highest character die roll."""
+    try:
+        action_dice = fortunedicerolls + characterdicerolls
+        action_dice.sort(reverse=True)
+        action_dice = action_dice[:2]
+        answer = f"**Action Total: {str(sum(action_dice))}** {str(action_dice)}\n"
+    except Exception as exc:
+        raise RollError(
+            "Coding error flattening dice rolls and creating total."
+        ) from exc
+    return answer
+
+
+def calc_impact(fortunedicerolls, characterdicerolls):
+    """Calculate the impact total"""
+    try:
+        # die results of 10 or higher on a d10 or 12 give two impact. It doesn't happen on a d20.
+        fortuneimpact = 1 if fortunedicerolls[0] >= 4 else 0
+        doublecharacterimpact = sum(2 for p in characterdicerolls if p >= 10)
+        characterimpact = sum(1 for p in characterdicerolls if 4 <= p < 10)
+        impact = fortuneimpact + doublecharacterimpact + characterimpact
+        impact = max(impact, 1)
+        answer = f"**Impact: {impact}** "
+        answer += (
+            f"(fortune={fortuneimpact} 2x={doublecharacterimpact} 1x={characterimpact})"
+        )
+    except Exception as exc:
+        raise RollError("Coding error calculating Impact") from exc
+    return answer
+
+
+def crit_fumble(fortunedicerolls, characterdicerolls):
+    """Check if we had a critical fumble. If so, add output and discard lowest non-1 die"""
+    answer = ""
+    newdicerolls = characterdicerolls
+    if fortunedicerolls[0] == 1:
+        answer += "**Critical Fumble**\n"
+        characterdicerolls.sort()
+        newdicerolls = []
+        scratched = False
+        for i in characterdicerolls:
+            if scratched:
+                newdicerolls.append(i)
+            elif i == 1:
+                newdicerolls.append(i)
+            else:
+                scratched = True
+                answer += f"*Scratched {i}*\n"
+                # no append because scratching this die
+
+        answer += "**Gain 1 inspiration point**\n"
+        answer += f"New character dice: {newdicerolls}\n"
+    return answer, newdicerolls
+
+
+def possible_fumble(fortunedicerolls):
+    """
+    You also critically fumble if your action is successfully countered
+    and you roll a 1-3 on the d20
+    """
+    answer = ""
+    if fortunedicerolls[0] <= 3:
+        answer += "**Possible Critical Fumble**\n"
+        answer += (
+            "If your action is successfully countered, gain 1 inspiration point.\n"
+        )
+    return answer

--- a/rollmvkhelpers.py
+++ b/rollmvkhelpers.py
@@ -32,7 +32,7 @@ def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
     fortunedicerolls = dicerolls[20]
 
     try:
-        if advantage or disadvantage:
+        if (advantage or disadvantage) and len(fortunedicerolls):
             logger.debug("Dicecounts %s", dicecounts)
             logger.debug("Dicerolls %s", dicerolls)
             answer += "Original d20s: "
@@ -53,9 +53,10 @@ def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
 
 
 def calc_action(fortunedicerolls, characterdicerolls):
-    """Compute the action total, using up to one d20 and the highest character die roll."""
+    """Compute the action total, using the highest two rolls. Up to one fortune die may be used."""
     try:
-        action_dice = fortunedicerolls + characterdicerolls
+        action_dice = sorted(fortunedicerolls, reverse=True)[:1]
+        action_dice += characterdicerolls
         action_dice.sort(reverse=True)
         action_dice = action_dice[:2]
         answer = f"**Action Total: {str(sum(action_dice))}** {str(action_dice)}\n"

--- a/rollplainhelpers.py
+++ b/rollplainhelpers.py
@@ -1,0 +1,61 @@
+#!.venv/bin/python3
+# MvKRoller: Dice roller for the MvK Dice Bot
+# Copyright (C) 2023 Eric Eisenhart
+# edited by CJ Holmes
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Helpers specific to the plain dice roller (plainroll)."""
+
+import re
+
+from rollcommon import RollError
+
+
+def print_d20_special(dicerolls):
+    """Checks for special d20 rules and adds stuff for any special stuff"""
+    answer = ""
+    try:
+        for size, values in dicerolls.items():
+            if len(values) == 1 and size == 20:
+                if values[0] == 1:
+                    answer += "\n1 is **Crit Fumble/Fail**"
+                elif values[0] == 20:
+                    answer += "\n20 is **Crit Success**"
+                elif values[0] % 2 == 0:
+                    answer += " (_Even_)"
+                else:
+                    answer += " (_Odd_)"
+
+                if values[0] == 2:  # separate because also even
+                    answer += "\n_Two-Weapon Hit?_"
+
+    except Exception as exc:
+        raise RollError("Coding error displaying Dice") from exc
+
+    return answer
+
+
+def parse_math(dicestr: str):
+    """Look for +N and -N things to get a total change"""
+
+    pattern_math = re.compile(r"([+-][0-9]+)")
+
+    amount = 0
+
+    for addstr in re.findall(pattern_math, dicestr):
+        amount += int(addstr)
+
+    return amount

--- a/test.py
+++ b/test.py
@@ -18,6 +18,8 @@
 # https://github.com/freiheit/MvKDiceBot
 """Test module for MvKDiceBot"""
 
+import asyncio
+import sys
 import unittest
 
 import mvkdicebot
@@ -65,11 +67,22 @@ class TestRoller(unittest.TestCase):
 class TestBotCommands(unittest.TestCase):
     """Test that the bot exposes both prefix and slash (app) commands.
 
-    Importing mvkdicebot only registers the commands; the bot never connects to
-    Discord here, so the live sync in setup_hook can't be unit-tested. The
-    runtime confirmation of a successful sync is the "Synced N application
-    command(s)" log line emitted on startup.
+    The commands live in cogs that setup_hook loads as extensions at startup;
+    here we load those extensions explicitly (the bot never connects to Discord,
+    so the live sync can't be unit-tested -- its runtime confirmation is the
+    "Synced N application command(s)" log line emitted on startup).
     """
+
+    @classmethod
+    def setUpClass(cls):
+        """Load the command cogs the same way setup_hook would."""
+
+        async def _load():
+            for extension in mvkdicebot.EXTENSIONS:
+                if extension not in mvkdicebot.bot.extensions:
+                    await mvkdicebot.bot.load_extension(extension)
+
+        asyncio.run(_load())
 
     def test_prefix_commands_registered(self):
         """The primary command names resolve as text/prefix commands."""
@@ -100,7 +113,10 @@ class TestBotCommands(unittest.TestCase):
 
     def test_help_command_routes_through_context(self):
         """The help command sends through the context so /help can reuse it."""
-        self.assertIsInstance(mvkdicebot.bot.help_command, mvkdicebot.HybridHelpCommand)
+        # Reference the class via the loaded extension module: load_extension
+        # replaces sys.modules["helpcog"], so a top-level import would be stale.
+        help_cls = sys.modules["helpcog"].HybridHelpCommand
+        self.assertIsInstance(mvkdicebot.bot.help_command, help_cls)
 
     def test_setup_hook_is_callable(self):
         """The startup sync hook is wired up."""

--- a/test.py
+++ b/test.py
@@ -19,6 +19,7 @@
 """Test module for MvKDiceBot"""
 
 import asyncio
+import random
 import sys
 import unittest
 
@@ -62,6 +63,129 @@ class TestRoller(unittest.TestCase):
         for dstring in strings:
             with self.subTest(dstring=dstring), self.assertRaises(roller.RollError):
                 roller.parse_dice(dstring)
+
+    def test_roller_exception(self):
+        """Ensure RollError exceptions carry messages properly."""
+        msg = "this is a message"
+        try:
+            raise roller.RollError(msg)
+        except roller.RollError as rex:
+            self.assertEqual(rex.getMessage(), msg)
+
+    def test_adv_disadv_good(self):
+        """Check behavior of adv_disadv() when given good data."""
+        data = [
+            [
+                True,
+                False,
+                {20: 2, 10: 1, 6: 2},
+                {20: [12, 7], 10: [1], 6: [7, 8]},
+                [12],
+            ],
+            [False, True, {20: 2, 10: 1, 6: 2}, {20: [12, 7], 10: [1], 6: [7, 8]}, [7]],
+            [
+                False,
+                False,
+                {20: 2, 10: 1, 6: 2},
+                {20: [12, 7], 10: [1], 6: [7, 8]},
+                [12, 7],
+            ],
+            [True, False, {20: 0, 10: 1, 6: 2}, {20: [], 10: [1], 6: [7, 8]}, []],
+            [True, False, {20: 1, 10: 1, 6: 2}, {20: [3], 10: [1], 6: [7, 8]}, [3]],
+            [False, True, {20: 1, 10: 1, 6: 2}, {20: [3], 10: [1], 6: [7, 8]}, [3]],
+        ]
+        for adv, dadv, dcount, droll, exp_fortune in data:
+            with self.subTest(advantage=adv, disadvantage=dadv, rolls=droll):
+                answer, fortune = roller.adv_disadv(adv, dadv, dcount, droll)
+                self.assertEqual(fortune, exp_fortune)
+                self.assertIsNotNone(answer)
+
+    def test_adv_disadv_bad(self):
+        """Force adv_disadv to fail with bad data and ensure RollError is raised."""
+        with self.assertRaises(roller.RollError):
+            roller.adv_disadv(True, False, {20: 2}, {20: "not an array"})
+
+    def test_roll_dice(self):
+        """Check the dice roller with a deterministic random source."""
+        dataset = [
+            [{}, {20: [], 12: [], 10: [], 8: [], 6: [], 4: []}],
+            [
+                {20: 2, 6: 5},
+                {20: [9, 5], 12: [], 10: [], 8: [], 6: [2, 2, 5, 2, 3], 4: []},
+            ],
+            [
+                {20: 1, 12: 1, 10: 1, 8: 1, 6: 1, 4: 1},
+                {20: [9], 12: [3], 10: [2], 8: [2], 6: [5], 4: [2]},
+            ],
+        ]
+        for dcount, result in dataset:
+            with self.subTest(dice_count=dcount):
+                self.assertEqual(roller.roll_dice(dcount, random.Random(99)), result)
+
+        # Without an explicit source we only check that we got a value.
+        the_rolls = roller.roll_dice({20: 1})
+        self.assertGreater(len(the_rolls[20]), 0)
+
+    def test_roll_dice_exc(self):
+        """Test attempts to roll dice with a bad dice count."""
+        dataset = [
+            {20: "nope!"},
+            {"8": 1},
+            {8: 12, "umbridge": "sucks"},
+        ]
+        for dcount in dataset:
+            with self.subTest(dice_count=dcount), self.assertRaises(roller.RollError):
+                roller.roll_dice(dcount)
+
+    def test_print_dice(self):
+        """Print some valid die rolls."""
+        dataset = [
+            [{}, "Dice: "],
+            [{20: [5, 12]}, "Dice: 2d20[5, 12] "],
+            [
+                {20: [], 12: [1, 12], 8: [1, 2, 3, 4], 4: [3, 2]},
+                "Dice: 2d12[1, 12] 4d8[1, 2, 3, 4] 2d4[3, 2] ",
+            ],
+        ]
+        for rolls, result in dataset:
+            with self.subTest(rolls=rolls):
+                self.assertEqual(roller.print_dice(rolls), result)
+
+    def test_print_dice_exc(self):
+        """print_dice raises when the input is not a dictionary."""
+        dataset = [
+            [20, 1],
+            "nobody",
+            99,
+        ]
+        for bad_roll in dataset:
+            with self.subTest(bad_roll=bad_roll), self.assertRaises(roller.RollError):
+                roller.print_dice(bad_roll)
+
+    def test_calc_action(self):
+        """Ensure actions are tallied properly (only the highest fortune die counts)."""
+        dataset = [
+            [[1, 20], [2, 4, 6, 8], "**Action Total: 28** [20, 8]\n"],
+            [[20, 1], [8, 6, 4, 2], "**Action Total: 28** [20, 8]\n"],
+            [[11, 13, 5], [8, 6, 4, 2], "**Action Total: 21** [13, 8]\n"],
+            [[6, 7, 8], [9, 10, 11, 12], "**Action Total: 23** [12, 11]\n"],
+        ]
+        for fdice, cdice, answer in dataset:
+            with self.subTest(dice=[fdice, cdice]):
+                self.assertEqual(roller.calc_action(fdice, cdice), answer)
+
+    def test_calc_action_exc(self):
+        """Give calc_action() some bad data."""
+        dataset = [
+            [None, None],
+            ["boopsie", "whoopsie"],
+            [12, 99],
+            [[1, 2], "grrrrr"],
+            ["grrrr", [1, 2]],
+        ]
+        for fdice, cdice in dataset:
+            with self.subTest(dice=[fdice, cdice]), self.assertRaises(roller.RollError):
+                roller.calc_action(fdice, cdice)
 
 
 class TestBotCommands(unittest.TestCase):


### PR DESCRIPTION
## What & why

Reorganizes the two large single-file modules into smaller, focused modules so
the "main logic" stays easy to follow, fixes issues found while reviewing the
refactor, salvages still-relevant test coverage from the stale `106-dev` branch,
and adds CI to run the tests. No user-facing behavior change, aside from `?help`
now grouping the dice commands under a "Roll" heading.

## Module structure

**Discord layer**
- `mvkdicebot.py` — the bot's shape: create the bot, `setup_hook` (load cogs +
  sync slash commands), `on_ready`, app-command error handler, `main()`.
- `mvkconfig.py` — config loading, logging setup, `primary_guilds` parsing.
- `rollcog.py` — `Roll` cog: `mvkroll`, `plainroll`, `/r`, `/p`, `_do_roll`.
- `helpcog.py` — `Help` cog + `HybridHelpCommand` powering `?help` and `/help`.

Cogs load as discord.py extensions in `setup_hook`.

**Roller logic** (all prefixed `roll*` so they sort together)
- `mvkroller.py` — top-level `mvkroll`/`plainroll`; re-exports `RollError`/
  `parse_dice` as a facade so callers are unchanged.
- `rollcommon.py` — shared parse/roll/display + `RollError`.
- `rollmvkhelpers.py` — MvK rules math.
- `rollplainhelpers.py` — plain-roll extras.

## Fixes (from a review of the refactor)

- **Don't cache the mutable `parse_dice` result** — `@functools.cache` returned a
  shared dict that `mvkroll` mutated in place, so a later roll of the same string
  could roll the wrong number of d20s.
- **Acknowledge slash interactions on unexpected errors** — a single
  `@bot.tree.error` handler ensures a slash command always replies.
- **Skip invalid `primary_guilds` entries** instead of crashing startup.
- **`calc_action` counts only the highest fortune die** (per the rules) and
  **`adv_disadv` guards an empty d20 list** (salvaged from `106-dev`).

## Tests & CI

- Ported the roller unit tests from `106-dev` (adapted to the new modules):
  coverage for `RollError`, `adv_disadv`, `roll_dice`, `print_dice`, and
  `calc_action` (good + error cases). `roll_dice` gained an injectable random
  source for deterministic tests. Suite is now 16 tests (was 7).
- Added a dedicated **Tests** GitHub workflow (`test.yml`) across Python
  3.10–3.14, removed the now-redundant test step from `python.yml`, and added a
  Tests badge.

## Verification

- `python test.py` — 16/16 pass (tests load the cogs as extensions, mirroring
  `setup_hook`)
- `ruff check` + `ruff format --check` clean; `pylint` 10.00/10
- Verified live against the dev instance.
