### PR TITLE
Roll tweaks: slash echo, forgiving modifiers, and a 13th Age escalation die tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ## project-specific:
 mvkdicebot.ini
 
+## Rulebook PDFs (large, copyrighted) kept locally for reference:
+*.pdf
+
 ## Editor/Linux:
 *~
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
 - `plainroll` — just rolls dice and adds up `+N`/`-N` modifiers. For a single
   d20 it also calls out 13th Age-flavored results (crit, fumble, even/odd,
   possible two-weapon hit). Also available as the slash command `/p`.
+- `escalation` — tracks the 13th Age escalation die (0–6) for the current
+  channel. `?escalation`/`/escalation` (text aliases `?esc`/`?e`, plus the `/esc`
+  slash command) shows it; `+1`/`next` advances a round, `-1`/`back` steps down,
+  `reset` starts a new battle, and a number `0`–`6` sets it. A channel's value
+  resets to 0 after 12 hours of inactivity.
 - `help` — auto-generated command list and usage. Available as `?help`,
   `@MvkDiceBot help`, or `/help` (optionally pass a command name, e.g.
   `/help command:mvkroll`).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
   does the same thing).
 - `plainroll` — just rolls dice and adds up `+N`/`-N` modifiers. For a single
   d20 it also calls out 13th Age-flavored results (crit, fumble, even/odd,
-  possible two-weapon hit). Also available as the slash command `/p`.
+  possible two-weapon hit) and, when this channel's escalation die is set, shows
+  it and an escalation-adjusted total. Also available as the slash command `/p`.
 - `escalation` — tracks the 13th Age escalation die (0–6) for the current
   channel. `?escalation`/`/escalation` (text aliases `?esc`/`?e`, plus the `/esc`
   slash command) shows it; `+1`/`next` advances a round, `-1`/`back` steps down,

--- a/escalationcog.py
+++ b/escalationcog.py
@@ -1,0 +1,175 @@
+#!.venv/bin/python3
+# MvKDiceBot: Discord bot for rolling dice for Mecha Vs Kaiju
+# Copyright (C) 2023  Eric Eisenhart
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Escalation die tracker for MvKDiceBot (13th Age).
+
+The escalation die runs 0-6: it starts at 0 (round 1, no bonus), advances by 1
+each round to a maximum of 6, and resets to 0 between battles. Heroes add it to
+their attack rolls. This cog tracks one value per channel, in memory, and lets a
+channel's value lapse back to 0 after a period of inactivity.
+"""
+
+import time
+
+from discord import app_commands
+from discord.ext import commands
+
+MAX_VALUE = 6
+# A channel's counter resets to 0 once it has gone untouched this long, so a
+# forgotten battle doesn't leave a stale value lying around.
+EXPIRY_SECONDS = 12 * 60 * 60
+
+
+def next_value(current, action):
+    """Return the new escalation-die value for ``action`` applied to ``current``.
+
+    Recognized actions: '+'/'+1'/'up'/'next'/'advance' (increment, caps at
+    MAX_VALUE), '-'/'-1'/'down'/'back' (decrement, floors at 0),
+    'reset'/'new'/'end' (set to 0), or a bare number 0-MAX_VALUE (set directly).
+    Raises ValueError for anything else.
+    """
+    action = action.strip().lower()
+
+    if action in ("+", "+1", "up", "next", "advance"):
+        return min(current + 1, MAX_VALUE)
+    if action in ("-", "-1", "down", "back"):
+        return max(current - 1, 0)
+    if action in ("reset", "new", "end"):
+        return 0
+    if action.isdigit():
+        value = int(action)
+        if 0 <= value <= MAX_VALUE:
+            return value
+
+    raise ValueError(f"Unrecognized escalation action: {action!r}")
+
+
+# Keycap emoji for each escalation-die value (the die only ranges 0-MAX_VALUE).
+NUMBER_EMOJI = {
+    0: ":zero:",
+    1: ":one:",
+    2: ":two:",
+    3: ":three:",
+    4: ":four:",
+    5: ":five:",
+    6: ":six:",
+}
+
+
+def format_value(value):
+    """Render an escalation-die value as a header, big emoji, and subtext."""
+    if value <= 0:
+        detail = "No bonus yet"
+    elif value >= MAX_VALUE:
+        detail = f"Players get +{value} to attacks (maximum)"
+    else:
+        detail = f"Players get +{value} to attacks"
+    return f"## Escalation Die Is\n# {NUMBER_EMOJI[value]}\n-# {detail}"
+
+
+class EscalationTracker:
+    """In-memory per-key escalation-die values that lapse to 0 after EXPIRY.
+
+    ``now`` is injectable so the expiry behavior can be unit-tested.
+    """
+
+    def __init__(self, now=time.monotonic, expiry=EXPIRY_SECONDS):
+        self._now = now
+        self._expiry = expiry
+        self._state = {}  # key -> (value, last_updated)
+
+    def get(self, key):
+        """Current value for ``key``, or 0 if unset or expired."""
+        entry = self._state.get(key)
+        if entry is None:
+            return 0
+        value, updated = entry
+        if self._now() - updated > self._expiry:
+            del self._state[key]
+            return 0
+        return value
+
+    def set(self, key, value):
+        """Store ``value`` for ``key`` and stamp it as just-updated."""
+        self._state[key] = (value, self._now())
+        return value
+
+
+USAGE = (
+    "Track the 13th Age escalation die (0-6). Usage: `?escalation` to show, "
+    "`+1`/`next` to advance, `-1`/`back` to step down, `reset` for a new battle, "
+    "or a number `0`-`6` to set it."
+)
+
+
+ACTION_HELP = "Blank to show; '+1'/'next', '-1'/'back', 'reset', or a number 0-6"
+
+
+class Escalation(commands.Cog):
+    """Tracks the 13th Age escalation die, one value per channel."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.tracker = EscalationTracker()
+
+    async def _handle(self, channel_id, action, send):
+        """Apply ``action`` to ``channel_id``'s value and reply via ``send``."""
+        current = self.tracker.get(channel_id)
+
+        if not action.strip():
+            await send(format_value(current))
+            return
+
+        try:
+            new_value = next_value(current, action)
+        except ValueError:
+            await send(USAGE)
+            return
+
+        self.tracker.set(channel_id, new_value)
+        await send(format_value(new_value))
+
+    @commands.hybrid_command(aliases=["esc", "e"])
+    @app_commands.describe(action=ACTION_HELP)
+    async def escalation(self, ctx, *, action: str = ""):
+        """Show or change the escalation die for this channel.
+
+        The escalation die (13th Age) starts at 0, goes up 1 per round to a max
+        of 6, and resets between battles. Usable as '?escalation'/'/escalation'
+        (text aliases '?esc', '?e'; also the '/esc' slash command). A channel's
+        value resets to 0 after 12 hours of inactivity.
+        """
+        await self._handle(ctx.channel.id, action, ctx.reply)
+
+    # Discord application commands have no alias mechanism, so '/esc' is its own
+    # slash command reusing the same handler (there is intentionally no '/e').
+    @app_commands.command(
+        name="esc",
+        description="Show or change the escalation die (same as /escalation)",
+    )
+    @app_commands.describe(action=ACTION_HELP)
+    async def esc_slash_alias(self, interaction, action: str = ""):
+        """Slash-command alias (/esc) for /escalation."""
+        await self._handle(
+            interaction.channel_id, action, interaction.response.send_message
+        )
+
+
+async def setup(bot):
+    """discord.py extension entry point: register the Escalation cog."""
+    await bot.add_cog(Escalation(bot))

--- a/escalationcog.py
+++ b/escalationcog.py
@@ -29,6 +29,8 @@ import time
 from discord import app_commands
 from discord.ext import commands
 
+from rollcommon import NUMBER_EMOJI
+
 MAX_VALUE = 6
 # A channel's counter resets to 0 once it has gone untouched this long, so a
 # forgotten battle doesn't leave a stale value lying around.
@@ -57,18 +59,6 @@ def next_value(current, action):
             return value
 
     raise ValueError(f"Unrecognized escalation action: {action!r}")
-
-
-# Keycap emoji for each escalation-die value (the die only ranges 0-MAX_VALUE).
-NUMBER_EMOJI = {
-    0: ":zero:",
-    1: ":one:",
-    2: ":two:",
-    3: ":three:",
-    4: ":four:",
-    5: ":five:",
-    6: ":six:",
-}
 
 
 def format_value(value):
@@ -126,6 +116,10 @@ class Escalation(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.tracker = EscalationTracker()
+
+    def current_escalation(self, channel_id):
+        """Current escalation die for a channel; used by other cogs (plainroll)."""
+        return self.tracker.get(channel_id)
 
     async def _handle(self, channel_id, action, send):
         """Apply ``action`` to ``channel_id``'s value and reply via ``send``."""

--- a/mvkdicebot.py
+++ b/mvkdicebot.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 # Cogs (loaded as discord.py extensions in setup_hook). Each module provides the
 # commands and an `async def setup(bot)` entry point.
-EXTENSIONS = ("rollcog", "helpcog")
+EXTENSIONS = ("rollcog", "helpcog", "escalationcog")
 
 # Guild IDs to register slash commands in directly, for instant updates instead
 # of waiting on global propagation. Populated from the config in main(); an empty

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -28,7 +28,7 @@ can keep using ``mvkroller.RollError`` / ``mvkroller.parse_dice``.
 import logging
 import re
 
-from rollcommon import RollError, parse_dice, print_dice, roll_dice
+from rollcommon import NUMBER_EMOJI, RollError, parse_dice, print_dice, roll_dice
 from rollmvkhelpers import (
     adv_disadv,
     calc_action,
@@ -110,8 +110,13 @@ def mvkroll(dicestr: str):
     return answer
 
 
-def plainroll(dicestr: str):
-    """Implementation of dice roller that just rolls some dice for you."""
+def plainroll(dicestr: str, escalation: int = 0):
+    """Implementation of dice roller that just rolls some dice for you.
+
+    ``escalation`` is the 13th Age escalation die for the channel. For a single
+    d20 (plus any +/- modifiers) it is shown and added to the total as a separate
+    "w/Esc" line, but only when it's actually in play (greater than 0).
+    """
 
     logger.debug("Roll %s", {dicestr})
 
@@ -127,6 +132,15 @@ def plainroll(dicestr: str):
     answer += print_d20_special(dicerolls)
     answer += "\n"
 
+    # A single d20 (modifiers don't count) is the standard 13th Age attack roll,
+    # so that's when the escalation die applies.
+    single_d20 = dicecounts[20] == 1 and all(
+        count == 0 for size, count in dicecounts.items() if size != 20
+    )
+    show_escalation = single_d20 and escalation > 0
+    if show_escalation:
+        answer += f"-# Esc: {NUMBER_EMOJI[escalation]}\n"
+
     total = 0
 
     if add_amount != 0:
@@ -138,5 +152,8 @@ def plainroll(dicestr: str):
         total += sum(values)
 
     answer += f"Total: **{total}**"
+
+    if show_escalation:
+        answer += f"\nw/Esc: **{total + escalation}**"
 
     return answer

--- a/rollcog.py
+++ b/rollcog.py
@@ -32,17 +32,24 @@ MVK_DICE_HELP = (
 PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
 
 
-async def _do_roll(send, roll_func, dicestr):
+async def _do_roll(send, roll_func, dicestr, echo_input=False):
     """Run a roller and send its output (or the error message) via ``send``.
 
     ``send`` is a coroutine that takes a single string: ``ctx.reply`` for the
     text/hybrid commands or ``interaction.response.send_message`` for the slash
     aliases. Re-raises RollError after reporting it so it is still logged.
+
+    When ``echo_input`` is set, the original roll string is prepended as a
+    quoted subtext line with the input in inline code (``> -# `...` ``). Slash
+    commands enable this because, unlike a text reply, the invocation isn't
+    otherwise visible to the channel; the backticks also stop any markdown or
+    mentions in the echoed string from being interpreted.
     """
+    prefix = f"> -# `{dicestr}`\n" if echo_input else ""
     try:
-        await send(roll_func(dicestr))
+        await send(prefix + roll_func(dicestr))
     except mvkroller.RollError as exc:
-        await send(exc.getMessage())
+        await send(prefix + exc.getMessage())
         raise
 
 
@@ -69,7 +76,12 @@ class Roll(commands.Cog):
 
         Ignores anything extra it doesn't understand.
         """
-        await _do_roll(ctx.reply, mvkroller.mvkroll, dicestr)
+        await _do_roll(
+            ctx.reply,
+            mvkroller.mvkroll,
+            dicestr,
+            echo_input=ctx.interaction is not None,
+        )
 
     @commands.hybrid_command(
         aliases=[
@@ -105,7 +117,12 @@ class Roll(commands.Cog):
         advantage/disadvantage, since in many rules and situations an 18 might
         be better than a 19 or a 2 better than a 16.
         """
-        await _do_roll(ctx.reply, mvkroller.plainroll, dicestr)
+        await _do_roll(
+            ctx.reply,
+            mvkroller.plainroll,
+            dicestr,
+            echo_input=ctx.interaction is not None,
+        )
 
     # Discord application commands have no alias mechanism, so the short '/r' and
     # '/p' forms are registered as their own slash commands that reuse the rollers.
@@ -115,7 +132,12 @@ class Roll(commands.Cog):
     @app_commands.describe(dicestr=MVK_DICE_HELP)
     async def mvkroll_slash_alias(self, interaction: discord.Interaction, dicestr: str):
         """Slash-command alias (/r) for /mvkroll."""
-        await _do_roll(interaction.response.send_message, mvkroller.mvkroll, dicestr)
+        await _do_roll(
+            interaction.response.send_message,
+            mvkroller.mvkroll,
+            dicestr,
+            echo_input=True,
+        )
 
     @app_commands.command(
         name="p", description="Roll a dice pool and total it (same as /plainroll)"
@@ -125,7 +147,12 @@ class Roll(commands.Cog):
         self, interaction: discord.Interaction, dicestr: str
     ):
         """Slash-command alias (/p) for /plainroll."""
-        await _do_roll(interaction.response.send_message, mvkroller.plainroll, dicestr)
+        await _do_roll(
+            interaction.response.send_message,
+            mvkroller.plainroll,
+            dicestr,
+            echo_input=True,
+        )
 
 
 async def setup(bot):

--- a/rollcog.py
+++ b/rollcog.py
@@ -18,6 +18,8 @@
 # https://github.com/freiheit/MvKDiceBot
 """Dice-rolling commands for MvKDiceBot (text, mention, and slash)."""
 
+import functools
+
 import discord
 from discord import app_commands
 from discord.ext import commands
@@ -58,6 +60,12 @@ class Roll(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
+
+    def _plainroller(self, channel_id):
+        """A plainroll callable bound to the channel's current escalation die."""
+        cog = self.bot.get_cog("Escalation")
+        escalation = cog.current_escalation(channel_id) if cog else 0
+        return functools.partial(mvkroller.plainroll, escalation=escalation)
 
     @commands.hybrid_command(aliases=["r", "R", "roll", "rolldice", "diceroll"])
     @app_commands.describe(dicestr=MVK_DICE_HELP)
@@ -119,7 +127,7 @@ class Roll(commands.Cog):
         """
         await _do_roll(
             ctx.reply,
-            mvkroller.plainroll,
+            self._plainroller(ctx.channel.id),
             dicestr,
             echo_input=ctx.interaction is not None,
         )
@@ -149,7 +157,7 @@ class Roll(commands.Cog):
         """Slash-command alias (/p) for /plainroll."""
         await _do_roll(
             interaction.response.send_message,
-            mvkroller.plainroll,
+            self._plainroller(interaction.channel_id),
             dicestr,
             echo_input=True,
         )

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -25,6 +25,21 @@ import re
 
 logger = logging.getLogger(__name__)
 
+# Keycap emoji for small integers, used in Discord output by both the rollers
+# (escalation line in plainroll) and the escalation tracker cog.
+NUMBER_EMOJI = {
+    0: ":zero:",
+    1: ":one:",
+    2: ":two:",
+    3: ":three:",
+    4: ":four:",
+    5: ":five:",
+    6: ":six:",
+    7: ":seven:",
+    8: ":eight:",
+    9: ":nine:",
+}
+
 
 class RollError(Exception):
     """Boring Exception Class"""

--- a/rollplainhelpers.py
+++ b/rollplainhelpers.py
@@ -49,13 +49,17 @@ def print_d20_special(dicerolls):
 
 
 def parse_math(dicestr: str):
-    """Look for +N and -N things to get a total change"""
+    """Look for +N and -N things to get a total change.
 
-    pattern_math = re.compile(r"([+-][0-9]+)")
+    Whitespace between the sign and the number is allowed, so '+7', '+ 7', and
+    '+  7' are all equivalent.
+    """
+
+    pattern_math = re.compile(r"([+-])\s*([0-9]+)")
 
     amount = 0
 
-    for addstr in re.findall(pattern_math, dicestr):
-        amount += int(addstr)
+    for sign, num in re.findall(pattern_math, dicestr):
+        amount += int(sign + num)
 
     return amount

--- a/test.py
+++ b/test.py
@@ -20,6 +20,7 @@
 
 import asyncio
 import random
+import re
 import sys
 import unittest
 
@@ -84,6 +85,22 @@ class TestRoller(unittest.TestCase):
         for dstring, expected in cases.items():
             with self.subTest(dstring=dstring):
                 self.assertEqual(roller.parse_math(dstring), expected)
+
+    def test_plainroll_escalation_shown(self):
+        """A single d20 with escalation > 0 shows the Esc line and escalated total."""
+        out = roller.plainroll("d20 +7", escalation=3)
+        self.assertIn("-# Esc: :three:", out)
+        total = int(re.search(r"Total: \*\*(-?\d+)\*\*", out).group(1))
+        w_esc = int(re.search(r"w/Esc: \*\*(-?\d+)\*\*", out).group(1))
+        self.assertEqual(w_esc, total + 3)
+
+    def test_plainroll_escalation_hidden(self):
+        """No escalation lines at 0, for multiple d20s, or when other dice are present."""
+        for dstring, esc in [("d20", 0), ("2d20", 3), ("d20 d6", 3)]:
+            with self.subTest(dstring=dstring, escalation=esc):
+                out = roller.plainroll(dstring, escalation=esc)
+                self.assertNotIn("Esc:", out)
+                self.assertNotIn("w/Esc", out)
 
     def test_roller_exception(self):
         """Ensure RollError exceptions carry messages properly."""

--- a/test.py
+++ b/test.py
@@ -25,6 +25,7 @@ import unittest
 
 import mvkdicebot
 import mvkroller as roller
+import rollcog
 
 
 class TestRoller(unittest.TestCase):
@@ -245,6 +246,45 @@ class TestBotCommands(unittest.TestCase):
     def test_setup_hook_is_callable(self):
         """The startup sync hook is wired up."""
         self.assertTrue(callable(mvkdicebot.bot.setup_hook))
+
+
+class TestRollEcho(unittest.TestCase):
+    """Test the optional input echo used by the slash commands."""
+
+    @staticmethod
+    def _capture():
+        """Return (captured_list, async send) that records what was sent."""
+        captured = []
+
+        async def send(msg):
+            captured.append(msg)
+
+        return captured, send
+
+    def test_echo_prepends_input(self):
+        """echo_input prepends the roll string as a '-# ' subtext line."""
+        captured, send = self._capture()
+        asyncio.run(
+            rollcog._do_roll(send, lambda s: "RESULT", "d20 +7", echo_input=True)
+        )
+        self.assertEqual(captured, ["> -# `d20 +7`\nRESULT"])
+
+    def test_no_echo_by_default(self):
+        """Without echo_input the output is unchanged (the text-command case)."""
+        captured, send = self._capture()
+        asyncio.run(rollcog._do_roll(send, lambda s: "RESULT", "d20 +7"))
+        self.assertEqual(captured, ["RESULT"])
+
+    def test_echo_on_error(self):
+        """The echo line is also prepended to a RollError message, then re-raised."""
+        captured, send = self._capture()
+
+        def boom(_):
+            raise roller.RollError("bad dice")
+
+        with self.assertRaises(roller.RollError):
+            asyncio.run(rollcog._do_roll(send, boom, "d99", echo_input=True))
+        self.assertEqual(captured, ["> -# `d99`\nbad dice"])
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -65,6 +65,25 @@ class TestRoller(unittest.TestCase):
             with self.subTest(dstring=dstring), self.assertRaises(roller.RollError):
                 roller.parse_dice(dstring)
 
+    def test_parse_math(self):
+        """+N/-N modifiers are summed, tolerating whitespace after the sign."""
+        cases = {
+            "": 0,
+            "d20": 0,
+            "+7": 7,
+            "+ 7": 7,
+            "+  7": 7,
+            "-3": -3,
+            "- 3": -3,
+            "d20+7": 7,
+            "d20 + 7": 7,
+            "+5 +2": 7,
+            "+5 - 2": 3,
+        }
+        for dstring, expected in cases.items():
+            with self.subTest(dstring=dstring):
+                self.assertEqual(roller.parse_math(dstring), expected)
+
     def test_roller_exception(self):
         """Ensure RollError exceptions carry messages properly."""
         msg = "this is a message"

--- a/test.py
+++ b/test.py
@@ -23,6 +23,7 @@ import random
 import sys
 import unittest
 
+import escalationcog
 import mvkdicebot
 import mvkroller as roller
 import rollcog
@@ -241,6 +242,8 @@ class TestBotCommands(unittest.TestCase):
             "roll": "mvkroll",
             "p": "plainroll",
             "justroll": "plainroll",
+            "esc": "escalation",
+            "e": "escalation",
         }
         for alias, target in aliases.items():
             with self.subTest(alias=alias):
@@ -251,7 +254,7 @@ class TestBotCommands(unittest.TestCase):
     def test_app_commands_in_tree(self):
         """The commands (incl. /r, /p, /help) are present in the application command tree."""
         app_names = {cmd.name for cmd in mvkdicebot.bot.tree.get_commands()}
-        for name in ("mvkroll", "plainroll", "help", "r", "p"):
+        for name in ("mvkroll", "plainroll", "help", "r", "p", "escalation", "esc"):
             with self.subTest(name=name):
                 self.assertIn(name, app_names)
 
@@ -304,6 +307,76 @@ class TestRollEcho(unittest.TestCase):
         with self.assertRaises(roller.RollError):
             asyncio.run(rollcog._do_roll(send, boom, "d99", echo_input=True))
         self.assertEqual(captured, ["> -# `d99`\nbad dice"])
+
+
+class TestEscalation(unittest.TestCase):
+    """Test the escalation-die value logic and the inactivity expiry."""
+
+    def test_next_value_increment_caps(self):
+        """+1/up/next increment but never exceed the maximum."""
+        for action in ("+", "+1", "up", "next", "advance"):
+            with self.subTest(action=action):
+                self.assertEqual(escalationcog.next_value(0, action), 1)
+                self.assertEqual(escalationcog.next_value(3, action), 4)
+                self.assertEqual(
+                    escalationcog.next_value(escalationcog.MAX_VALUE, action),
+                    escalationcog.MAX_VALUE,
+                )
+
+    def test_next_value_decrement_floors(self):
+        """-1/down/back decrement but never go below 0."""
+        for action in ("-", "-1", "down", "back"):
+            with self.subTest(action=action):
+                self.assertEqual(escalationcog.next_value(3, action), 2)
+                self.assertEqual(escalationcog.next_value(0, action), 0)
+
+    def test_next_value_reset_and_set(self):
+        """reset/new/end go to 0; a bare number sets directly."""
+        for action in ("reset", "new", "end", "0"):
+            with self.subTest(action=action):
+                self.assertEqual(escalationcog.next_value(5, action), 0)
+        self.assertEqual(escalationcog.next_value(0, "3"), 3)
+        self.assertEqual(escalationcog.next_value(2, "6"), 6)
+
+    def test_next_value_bad_input(self):
+        """Out-of-range or unrecognized actions raise ValueError."""
+        for action in ("7", "99", "+2", "banana", "-3"):
+            with self.subTest(action=action), self.assertRaises(ValueError):
+                escalationcog.next_value(0, action)
+
+    def test_tracker_per_key_isolation(self):
+        """Different channels track independent values."""
+        tracker = escalationcog.EscalationTracker(now=lambda: 0.0)
+        tracker.set("a", 3)
+        tracker.set("b", 5)
+        self.assertEqual(tracker.get("a"), 3)
+        self.assertEqual(tracker.get("b"), 5)
+        self.assertEqual(tracker.get("never-set"), 0)
+
+    def test_tracker_expiry(self):
+        """A value lapses back to 0 once it has gone untouched past EXPIRY."""
+        clock = {"t": 1000.0}
+        tracker = escalationcog.EscalationTracker(now=lambda: clock["t"], expiry=100)
+        tracker.set("chan", 4)
+        clock["t"] += 50  # still fresh
+        self.assertEqual(tracker.get("chan"), 4)
+        clock["t"] += 100  # now 150s since set, past the 100s expiry
+        self.assertEqual(tracker.get("chan"), 0)
+
+    def test_format_value(self):
+        """Formatting uses a header, a keycap emoji, and a subtext detail line."""
+        zero = escalationcog.format_value(0)
+        self.assertIn("## Escalation Die Is", zero)
+        self.assertIn(":zero:", zero)
+        self.assertIn("No bonus yet", zero)
+
+        three = escalationcog.format_value(3)
+        self.assertIn(":three:", three)
+        self.assertIn("+3", three)
+
+        maxed = escalationcog.format_value(escalationcog.MAX_VALUE)
+        self.assertIn(":six:", maxed)
+        self.assertIn("maximum", maxed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

A batch of small gameplay tweaks to the roll commands, plus a new escalation-die
tracker informed by the 13th Age 2nd Ed rulebooks.

## Changes

- **Slash rolls echo the input** — `/mvkroll`, `/plainroll`, `/r`, `/p` prepend
  the original roll string as a quoted subtext line (`` > -# `d20 +7` ``). Text and
  mention rolls are unchanged (their reply already shows the request).
- **Forgiving modifier parsing** — `plainroll` now accepts whitespace between the
  sign and number, so `d20+7`, `d20 +7`, and `d20 + 7` are equivalent.
- **Escalation die tracker** (`escalation`, text aliases `esc`/`e`, plus `/esc`):
  tracks the 13th Age escalation die (0–6) per channel. `+1`/`next` advances,
  `-1`/`back` steps down, `reset` for a new battle, or a number to set it.
  In-memory; a channel's value lapses to 0 after 12 hours of inactivity. Output
  is a header + keycap emoji + subtext.
- **plainroll uses the escalation die** — for a single d20 (modifiers allowed),
  when the channel's die is > 0, `plainroll` shows an `-# Esc: :n:` line and a
  `w/Esc` total. At 0 (idle) or for other dice, output is unchanged.
- **chore:** gitignore PDF rulebook files.

## Notes

- The escalation die is a per-channel counter, not derived from a roll, so it's a
  separate command rather than something `plainroll` computes. `mvkroller` stays
  Discord-free; `rollcog` reads the value from the Escalation cog via
  `bot.get_cog(...)` and the shared `NUMBER_EMOJI` map lives in `rollcommon`.
- Considered (and skipped, per discussion) adding natural-threshold callouts
  (16+, etc.) to `plainroll` — they're too character-specific to flag generically.

## Verification

- `python test.py` — 29/29 pass (incl. parse_math whitespace, slash-echo,
  escalation value logic + 12h expiry via injected clock, and plainroll's
  escalation lines)
- `ruff check` + `ruff format --check` clean; `pylint` 10.00/10
- Verified live against the dev instance for each command.
