### PR TITLE
Roll revisions: edit in place, re-roll only added dice (closes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
   `/help command:mvkroll`).
 
 Editing a text/mention roll message updates the bot's existing reply and
-re-rolls only the dice you added (existing dice are kept). Slash commands can't
-be edited, so this applies to the `?`/mention forms only.
+re-rolls only the dice you added (existing dice are kept). Each prior `Dice:`
+line is shown above the new result, struck through as small text, so others can
+see what changed. Slash commands can't be edited, so this applies to the
+`?`/mention forms only.
 
 Slash commands are registered with Discord automatically on startup. If you set
 `primary_guilds` (a list of guild/server IDs) in `mvkdicebot.ini`, they are

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
   `@MvkDiceBot help`, or `/help` (optionally pass a command name, e.g.
   `/help command:mvkroll`).
 
+Editing a text/mention roll message updates the bot's existing reply and
+re-rolls only the dice you added (existing dice are kept). Slash commands can't
+be edited, so this applies to the `?`/mention forms only.
+
 Slash commands are registered with Discord automatically on startup. If you set
 `primary_guilds` (a list of guild/server IDs) in `mvkdicebot.ini`, they are
 synced to those servers instantly. Otherwise they are synced globally, which can

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -28,7 +28,14 @@ can keep using ``mvkroller.RollError`` / ``mvkroller.parse_dice``.
 import logging
 import re
 
-from rollcommon import NUMBER_EMOJI, RollError, parse_dice, print_dice, roll_dice
+from rollcommon import (
+    NUMBER_EMOJI,
+    RollError,
+    merge_rolls,
+    parse_dice,
+    print_dice,
+    roll_dice,
+)
 from rollmvkhelpers import (
     adv_disadv,
     calc_action,
@@ -41,8 +48,14 @@ from rollplainhelpers import parse_math, print_d20_special
 logger = logging.getLogger(__name__)
 
 
-def mvkroll(dicestr: str):
-    """Implementation of dice roller that applies MvK rules."""
+def mvkroll(dicestr: str, prior_rolls=None):
+    """Implementation of dice roller that applies MvK rules.
+
+    Returns ``(text, rolls)`` where ``rolls`` is the raw per-size dice rolled
+    (captured before the MvK math mutates them). Passing a previous ``rolls`` as
+    ``prior_rolls`` reuses those dice and only rolls newly-added ones, so editing
+    a roll re-rolls just the additions.
+    """
 
     logger.debug("Roll %s", {dicestr})
 
@@ -67,7 +80,14 @@ def mvkroll(dicestr: str):
         dicecounts[20] = 1
         answer += "_No advantage/disadvantage, setting 1d20_\n"
 
-    dicerolls = roll_dice(dicecounts)
+    if prior_rolls is None:
+        dicerolls = roll_dice(dicecounts)
+    else:
+        dicerolls = merge_rolls(prior_rolls, dicecounts)
+
+    # Snapshot the raw rolls before the MvK math sorts/discards dice, so an edit
+    # can reuse them.
+    rolls = {size: list(values) for size, values in dicerolls.items()}
 
     # the d20 is called the "Fortune Die"
     fortunedicerolls = dicerolls[20]
@@ -107,15 +127,18 @@ def mvkroll(dicestr: str):
 
     answer += calc_impact(fortunedicerolls, characterdicerolls)
 
-    return answer
+    return answer, rolls
 
 
-def plainroll(dicestr: str, escalation: int = 0):
+def plainroll(dicestr: str, escalation: int = 0, prior_rolls=None):
     """Implementation of dice roller that just rolls some dice for you.
 
     ``escalation`` is the 13th Age escalation die for the channel. For a single
     d20 (plus any +/- modifiers) it is shown and added to the total as a separate
     "w/Esc" line, but only when it's actually in play (greater than 0).
+
+    Returns ``(text, rolls)``; passing a previous ``rolls`` as ``prior_rolls``
+    reuses those dice and only rolls newly-added ones (for edited rolls).
     """
 
     logger.debug("Roll %s", {dicestr})
@@ -126,7 +149,10 @@ def plainroll(dicestr: str, escalation: int = 0):
     logger.debug("add_amount %s", {add_amount})
 
     dicecounts = parse_dice(dicestr)
-    dicerolls = roll_dice(dicecounts)
+    if prior_rolls is None:
+        dicerolls = roll_dice(dicecounts)
+    else:
+        dicerolls = merge_rolls(prior_rolls, dicecounts)
 
     answer += print_dice(dicerolls)
     answer += print_d20_special(dicerolls)
@@ -156,4 +182,4 @@ def plainroll(dicestr: str, escalation: int = 0):
     if show_escalation:
         answer += f"\nw/Esc: **{total + escalation}**"
 
-    return answer
+    return answer, dicerolls

--- a/rollcog.py
+++ b/rollcog.py
@@ -37,6 +37,14 @@ PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
 # How many recent text rolls to remember (message -> our reply) for edit handling.
 MAX_TRACKED = 200
 
+# State kept per text-roll trigger message so edits can update the same reply,
+# re-roll only the added dice, and show prior dice lines struck through.
+#   reply   - the Message we sent
+#   rolls   - the raw dice rolled (passed back in as prior_rolls on edit)
+#   text    - the current roll's rendered body (its 'Dice:' line is struck next edit)
+#   history - struck-through 'Dice:' lines from previous versions of this roll
+RollState = collections.namedtuple("RollState", "reply rolls text history")
+
 
 def echo_prefix(dicestr):
     """Quoted-subtext echo of the roll string, shown only for slash commands.
@@ -47,13 +55,27 @@ def echo_prefix(dicestr):
     return f"> -# `{dicestr}`\n"
 
 
+def dice_line(text):
+    """Return the 'Dice: ...' line from a roll's rendered body, or None."""
+    for line in text.split("\n"):
+        if line.startswith("Dice:"):
+            return line.rstrip()
+    return None
+
+
+def render_with_history(history, body):
+    """Stack struck-through history lines (if any) above the current body."""
+    if history:
+        return "\n".join(history) + "\n" + body
+    return body
+
+
 class Roll(commands.Cog):
     """MvK dice-rolling commands."""
 
     def __init__(self, bot):
         self.bot = bot
-        # Text rolls remember `your message id -> (our reply, dice rolled)` so an
-        # edit can update the same reply and re-roll only the dice that changed.
+        # trigger message id -> RollState, for editing text rolls in place.
         self.replies = collections.OrderedDict()
 
     def _plainroller(self, channel_id):
@@ -62,37 +84,50 @@ class Roll(commands.Cog):
         escalation = cog.current_escalation(channel_id) if cog else 0
         return functools.partial(mvkroller.plainroll, escalation=escalation)
 
-    def _remember(self, message_id, reply, rolls):
-        """Track (reply, rolls) for a trigger message, bounding the cache size."""
-        self.replies[message_id] = (reply, rolls)
+    def _remember(self, message_id, state):
+        """Track a RollState for a trigger message, bounding the cache size."""
+        self.replies[message_id] = state
         self.replies.move_to_end(message_id)
         while len(self.replies) > MAX_TRACKED:
             self.replies.popitem(last=False)
 
-    async def _respond_text(self, ctx, content, rolls):
-        """Reply to a text roll, or edit our existing reply if it was edited."""
+    async def _post(self, ctx, content, state):
+        """Reply to a text roll, or edit our existing reply, then store the state."""
         existing = self.replies.get(ctx.message.id)
-        if existing is not None:
-            reply = existing[0]
+        reply = existing.reply if existing else None
+        if reply is not None:
             try:
                 await reply.edit(content=content)
-                self._remember(ctx.message.id, reply, rolls)
-                return
             except discord.HTTPException:
-                pass  # our reply is gone; fall through and post a fresh one
-        reply = await ctx.reply(content)
-        self._remember(ctx.message.id, reply, rolls)
+                reply = None  # our reply is gone; post a fresh one
+        if reply is None:
+            reply = await ctx.reply(content)
+        self._remember(
+            ctx.message.id, RollState(reply, state.rolls, state.text, state.history)
+        )
 
     async def _run_text_roll(self, ctx, roller, dicestr):
-        """Run a roller for a text/mention invocation (reply tracked, prior reused)."""
-        existing = self.replies.get(ctx.message.id)
-        prior = existing[1] if existing else None
+        """Run a roller for a text/mention invocation (tracked, prior reused)."""
+        prev = self.replies.get(ctx.message.id)
+        prior_rolls = prev.rolls if prev else None
+        prior_history = prev.history if prev else []
+        prior_text = prev.text if prev else ""
+
         try:
-            text, rolls = roller(dicestr, prior_rolls=prior)
+            text, rolls = roller(dicestr, prior_rolls=prior_rolls)
         except mvkroller.RollError as exc:
-            await self._respond_text(ctx, exc.getMessage(), None)
+            content = render_with_history(prior_history, exc.getMessage())
+            await self._post(
+                ctx, content, RollState(None, prior_rolls, prior_text, prior_history)
+            )
             raise
-        await self._respond_text(ctx, text, rolls)
+
+        history = list(prior_history)
+        previous = dice_line(prior_text)
+        if previous:
+            history.append(f"-# ~~{previous}~~")
+        content = render_with_history(history, text)
+        await self._post(ctx, content, RollState(None, rolls, text, history))
 
     async def _run_slash_roll(self, interaction, roller, dicestr):
         """Run a roller for a slash invocation (echo the input, no edit tracking)."""

--- a/rollcog.py
+++ b/rollcog.py
@@ -18,6 +18,7 @@
 # https://github.com/freiheit/MvKDiceBot
 """Dice-rolling commands for MvKDiceBot (text, mention, and slash)."""
 
+import collections
 import functools
 
 import discord
@@ -33,26 +34,17 @@ MVK_DICE_HELP = (
 )
 PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
 
+# How many recent text rolls to remember (message -> our reply) for edit handling.
+MAX_TRACKED = 200
 
-async def _do_roll(send, roll_func, dicestr, echo_input=False):
-    """Run a roller and send its output (or the error message) via ``send``.
 
-    ``send`` is a coroutine that takes a single string: ``ctx.reply`` for the
-    text/hybrid commands or ``interaction.response.send_message`` for the slash
-    aliases. Re-raises RollError after reporting it so it is still logged.
+def echo_prefix(dicestr):
+    """Quoted-subtext echo of the roll string, shown only for slash commands.
 
-    When ``echo_input`` is set, the original roll string is prepended as a
-    quoted subtext line with the input in inline code (``> -# `...` ``). Slash
-    commands enable this because, unlike a text reply, the invocation isn't
-    otherwise visible to the channel; the backticks also stop any markdown or
-    mentions in the echoed string from being interpreted.
+    A slash invocation isn't otherwise visible to the channel, so we echo it. The
+    backticks keep any markdown or mentions in the string from being interpreted.
     """
-    prefix = f"> -# `{dicestr}`\n" if echo_input else ""
-    try:
-        await send(prefix + roll_func(dicestr))
-    except mvkroller.RollError as exc:
-        await send(prefix + exc.getMessage())
-        raise
+    return f"> -# `{dicestr}`\n"
 
 
 class Roll(commands.Cog):
@@ -60,12 +52,57 @@ class Roll(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
+        # Text rolls remember `your message id -> (our reply, dice rolled)` so an
+        # edit can update the same reply and re-roll only the dice that changed.
+        self.replies = collections.OrderedDict()
 
     def _plainroller(self, channel_id):
         """A plainroll callable bound to the channel's current escalation die."""
         cog = self.bot.get_cog("Escalation")
         escalation = cog.current_escalation(channel_id) if cog else 0
         return functools.partial(mvkroller.plainroll, escalation=escalation)
+
+    def _remember(self, message_id, reply, rolls):
+        """Track (reply, rolls) for a trigger message, bounding the cache size."""
+        self.replies[message_id] = (reply, rolls)
+        self.replies.move_to_end(message_id)
+        while len(self.replies) > MAX_TRACKED:
+            self.replies.popitem(last=False)
+
+    async def _respond_text(self, ctx, content, rolls):
+        """Reply to a text roll, or edit our existing reply if it was edited."""
+        existing = self.replies.get(ctx.message.id)
+        if existing is not None:
+            reply = existing[0]
+            try:
+                await reply.edit(content=content)
+                self._remember(ctx.message.id, reply, rolls)
+                return
+            except discord.HTTPException:
+                pass  # our reply is gone; fall through and post a fresh one
+        reply = await ctx.reply(content)
+        self._remember(ctx.message.id, reply, rolls)
+
+    async def _run_text_roll(self, ctx, roller, dicestr):
+        """Run a roller for a text/mention invocation (reply tracked, prior reused)."""
+        existing = self.replies.get(ctx.message.id)
+        prior = existing[1] if existing else None
+        try:
+            text, rolls = roller(dicestr, prior_rolls=prior)
+        except mvkroller.RollError as exc:
+            await self._respond_text(ctx, exc.getMessage(), None)
+            raise
+        await self._respond_text(ctx, text, rolls)
+
+    async def _run_slash_roll(self, interaction, roller, dicestr):
+        """Run a roller for a slash invocation (echo the input, no edit tracking)."""
+        prefix = echo_prefix(dicestr)
+        try:
+            text, _ = roller(dicestr, prior_rolls=None)
+        except mvkroller.RollError as exc:
+            await interaction.response.send_message(prefix + exc.getMessage())
+            raise
+        await interaction.response.send_message(prefix + text)
 
     @commands.hybrid_command(aliases=["r", "R", "roll", "rolldice", "diceroll"])
     @app_commands.describe(dicestr=MVK_DICE_HELP)
@@ -82,14 +119,13 @@ class Roll(commands.Cog):
         Example: '?roll 2d20 2d10 advantage'
         Example: '?roll 2d20 2d10 disadvantage'
 
-        Ignores anything extra it doesn't understand.
+        Ignores anything extra it doesn't understand. Editing a text roll re-rolls
+        only the dice you added and updates the same reply.
         """
-        await _do_roll(
-            ctx.reply,
-            mvkroller.mvkroll,
-            dicestr,
-            echo_input=ctx.interaction is not None,
-        )
+        if ctx.interaction is None:
+            await self._run_text_roll(ctx, mvkroller.mvkroll, dicestr)
+        else:
+            await self._run_slash_roll(ctx.interaction, mvkroller.mvkroll, dicestr)
 
     @commands.hybrid_command(
         aliases=[
@@ -125,12 +161,11 @@ class Roll(commands.Cog):
         advantage/disadvantage, since in many rules and situations an 18 might
         be better than a 19 or a 2 better than a 16.
         """
-        await _do_roll(
-            ctx.reply,
-            self._plainroller(ctx.channel.id),
-            dicestr,
-            echo_input=ctx.interaction is not None,
-        )
+        roller = self._plainroller(ctx.channel.id)
+        if ctx.interaction is None:
+            await self._run_text_roll(ctx, roller, dicestr)
+        else:
+            await self._run_slash_roll(ctx.interaction, roller, dicestr)
 
     # Discord application commands have no alias mechanism, so the short '/r' and
     # '/p' forms are registered as their own slash commands that reuse the rollers.
@@ -140,12 +175,7 @@ class Roll(commands.Cog):
     @app_commands.describe(dicestr=MVK_DICE_HELP)
     async def mvkroll_slash_alias(self, interaction: discord.Interaction, dicestr: str):
         """Slash-command alias (/r) for /mvkroll."""
-        await _do_roll(
-            interaction.response.send_message,
-            mvkroller.mvkroll,
-            dicestr,
-            echo_input=True,
-        )
+        await self._run_slash_roll(interaction, mvkroller.mvkroll, dicestr)
 
     @app_commands.command(
         name="p", description="Roll a dice pool and total it (same as /plainroll)"
@@ -155,12 +185,21 @@ class Roll(commands.Cog):
         self, interaction: discord.Interaction, dicestr: str
     ):
         """Slash-command alias (/p) for /plainroll."""
-        await _do_roll(
-            interaction.response.send_message,
-            self._plainroller(interaction.channel_id),
-            dicestr,
-            echo_input=True,
-        )
+        roller = self._plainroller(interaction.channel_id)
+        await self._run_slash_roll(interaction, roller, dicestr)
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before, after):
+        """Re-run an edited roll, reusing prior dice and editing our reply.
+
+        Only this cog's roll commands are re-run, so stateful commands (like the
+        escalation tracker) are never double-executed by a message edit.
+        """
+        if before.content == after.content:
+            return
+        ctx = await self.bot.get_context(after)
+        if ctx.command is not None and ctx.cog is self:
+            await self.bot.invoke(ctx)
 
 
 async def setup(bot):

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -122,10 +122,11 @@ def roll_dice(dicecounts, rand_source=None):
 def merge_rolls(prior, dicecounts, rand_source=None):
     """Reuse prior per-size rolls, rolling only the newly-added dice.
 
-    For each die size, keep up to ``dicecounts[size]`` of ``prior``'s rolls (the
-    earliest-rolled ones) and roll any additional dice; if the count dropped, the
-    extra prior rolls are discarded. This makes editing a roll re-roll only the
-    dice that were added, leaving the others as they were.
+    For each die size, keep up to ``dicecounts[size]`` of ``prior``'s rolls and
+    roll any additional dice; if the count dropped, a random subset of the prior
+    rolls is kept (so editing down doesn't always discard the same dice). This
+    makes editing a roll re-roll only the dice that were added, leaving the others
+    as they were.
     """
     dicerolls = _empty_dicerolls()
 
@@ -135,7 +136,8 @@ def merge_rolls(prior, dicecounts, rand_source=None):
 
         for size in dicerolls:
             want = dicecounts.get(size, 0)
-            kept = list(prior.get(size, []))[:want]
+            have = list(prior.get(size, []))
+            kept = rand_source.sample(have, want) if want < len(have) else have
             extra = [_roll_one(size, rand_source) for _ in range(want - len(kept))]
             dicerolls[size] = kept + extra
     except Exception as exc:

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -87,23 +87,22 @@ def parse_dice(dicestr: str):
     return dicecounts
 
 
+def _roll_one(size, rand_source):
+    """Roll a single die of the given size with the given random.Random."""
+    return int(rand_source.random() * size) + 1
+
+
+def _empty_dicerolls():
+    return {20: [], 12: [], 10: [], 8: [], 6: [], 4: []}
+
+
 def roll_dice(dicecounts, rand_source=None):
     """Returns a dictionary of dieSize => rolls[]
 
     A `rand_source` (a random.Random instance) may be supplied so tests can roll
     deterministically; by default a fresh random.Random() is used.
     """
-    dicerolls = {
-        20: [],
-        12: [],
-        10: [],
-        8: [],
-        6: [],
-        4: [],
-    }
-
-    def rollit(size, src):
-        return int(src.random() * size) + 1
+    dicerolls = _empty_dicerolls()
 
     try:
         if rand_source is None:
@@ -111,9 +110,36 @@ def roll_dice(dicecounts, rand_source=None):
 
         for size, num in dicecounts.items():
             if num > 0:
-                dicerolls[size] = [rollit(size, rand_source) for idx in range(0, num)]
+                dicerolls[size] = [
+                    _roll_one(size, rand_source) for idx in range(0, num)
+                ]
     except Exception as exc:
         raise RollError("Exception while rolling dice.") from exc
+
+    return dicerolls
+
+
+def merge_rolls(prior, dicecounts, rand_source=None):
+    """Reuse prior per-size rolls, rolling only the newly-added dice.
+
+    For each die size, keep up to ``dicecounts[size]`` of ``prior``'s rolls (the
+    earliest-rolled ones) and roll any additional dice; if the count dropped, the
+    extra prior rolls are discarded. This makes editing a roll re-roll only the
+    dice that were added, leaving the others as they were.
+    """
+    dicerolls = _empty_dicerolls()
+
+    try:
+        if rand_source is None:
+            rand_source = random.Random()
+
+        for size in dicerolls:
+            want = dicecounts.get(size, 0)
+            kept = list(prior.get(size, []))[:want]
+            extra = [_roll_one(size, rand_source) for _ in range(want - len(kept))]
+            dicerolls[size] = kept + extra
+    except Exception as exc:
+        raise RollError("Exception while merging dice rolls.") from exc
 
     return dicerolls
 

--- a/test.py
+++ b/test.py
@@ -305,6 +305,22 @@ class TestRevisions(unittest.TestCase):
         """Slash rolls echo the input as a quoted-subtext inline-code line."""
         self.assertEqual(rollcog.echo_prefix("d20 +7"), "> -# `d20 +7`\n")
 
+    def test_dice_line(self):
+        """dice_line picks out the 'Dice:' line (and ignores a trailing space)."""
+        body = "Dice: 6d10[7, 5, 4, 1, 7, 5] \nTotal: **29**"
+        self.assertEqual(rollcog.dice_line(body), "Dice: 6d10[7, 5, 4, 1, 7, 5]")
+        self.assertIsNone(rollcog.dice_line("Not enough dice to roll"))
+
+    def test_render_with_history(self):
+        """History lines (struck-through) stack above the current body; none if empty."""
+        body = "Dice: 7d10[...] \nTotal: **30**"
+        self.assertEqual(rollcog.render_with_history([], body), body)
+        history = ["-# ~~Dice: 6d10[7, 5, 4, 1, 7, 5]~~"]
+        self.assertEqual(
+            rollcog.render_with_history(history, body),
+            "-# ~~Dice: 6d10[7, 5, 4, 1, 7, 5]~~\n" + body,
+        )
+
     def test_merge_keeps_prior_and_rolls_extra(self):
         """Added dice are rolled fresh; existing dice are kept (earliest first)."""
         merged = roller.merge_rolls({20: [14]}, {20: 2}, random.Random(1))
@@ -312,9 +328,21 @@ class TestRevisions(unittest.TestCase):
         self.assertEqual(merged[20][0], 14)
 
     def test_merge_drops_extra_when_count_decreases(self):
-        """Removing dice keeps the earliest-rolled ones."""
-        merged = roller.merge_rolls({6: [1, 2, 3]}, {6: 1})
-        self.assertEqual(merged[6], [1])
+        """Reducing the count keeps a random subset of the prior rolls."""
+        merged = roller.merge_rolls({6: [1, 2, 3]}, {6: 1}, random.Random(0))
+        self.assertEqual(len(merged[6]), 1)
+        self.assertIn(merged[6][0], [1, 2, 3])
+
+    def test_merge_kept_subset_varies(self):
+        """Which dice are kept when reducing isn't always the same."""
+        prior = {10: [1, 2, 3, 4, 5, 6, 7, 8]}
+        seen = set()
+        for seed in range(20):
+            kept = roller.merge_rolls(prior, {10: 2}, random.Random(seed))[10]
+            self.assertEqual(len(kept), 2)
+            self.assertTrue(set(kept) <= set(prior[10]))
+            seen.add(tuple(sorted(kept)))
+        self.assertGreater(len(seen), 1)
 
     def test_merge_unchanged_counts_reuse_all(self):
         """When counts don't change, every prior die is reused (e.g. only +N edited)."""

--- a/test.py
+++ b/test.py
@@ -88,7 +88,7 @@ class TestRoller(unittest.TestCase):
 
     def test_plainroll_escalation_shown(self):
         """A single d20 with escalation > 0 shows the Esc line and escalated total."""
-        out = roller.plainroll("d20 +7", escalation=3)
+        out, _rolls = roller.plainroll("d20 +7", escalation=3)
         self.assertIn("-# Esc: :three:", out)
         total = int(re.search(r"Total: \*\*(-?\d+)\*\*", out).group(1))
         w_esc = int(re.search(r"w/Esc: \*\*(-?\d+)\*\*", out).group(1))
@@ -98,9 +98,20 @@ class TestRoller(unittest.TestCase):
         """No escalation lines at 0, for multiple d20s, or when other dice are present."""
         for dstring, esc in [("d20", 0), ("2d20", 3), ("d20 d6", 3)]:
             with self.subTest(dstring=dstring, escalation=esc):
-                out = roller.plainroll(dstring, escalation=esc)
+                out, _rolls = roller.plainroll(dstring, escalation=esc)
                 self.assertNotIn("Esc:", out)
                 self.assertNotIn("w/Esc", out)
+
+    def test_roller_returns_rolls(self):
+        """The rollers return (text, rolls) so edits can reuse the dice."""
+        text, rolls = roller.plainroll("2d6")
+        self.assertIsInstance(text, str)
+        self.assertEqual(len(rolls[6]), 2)
+
+        text, rolls = roller.mvkroll("d20 2d8")
+        self.assertIsInstance(text, str)
+        self.assertEqual(len(rolls[20]), 1)
+        self.assertEqual(len(rolls[8]), 2)
 
     def test_roller_exception(self):
         """Ensure RollError exceptions carry messages properly."""
@@ -287,43 +298,36 @@ class TestBotCommands(unittest.TestCase):
         self.assertTrue(callable(mvkdicebot.bot.setup_hook))
 
 
-class TestRollEcho(unittest.TestCase):
-    """Test the optional input echo used by the slash commands."""
+class TestRevisions(unittest.TestCase):
+    """Test the pieces behind editing/echoing a roll (issue #13)."""
 
-    @staticmethod
-    def _capture():
-        """Return (captured_list, async send) that records what was sent."""
-        captured = []
+    def test_echo_prefix(self):
+        """Slash rolls echo the input as a quoted-subtext inline-code line."""
+        self.assertEqual(rollcog.echo_prefix("d20 +7"), "> -# `d20 +7`\n")
 
-        async def send(msg):
-            captured.append(msg)
+    def test_merge_keeps_prior_and_rolls_extra(self):
+        """Added dice are rolled fresh; existing dice are kept (earliest first)."""
+        merged = roller.merge_rolls({20: [14]}, {20: 2}, random.Random(1))
+        self.assertEqual(len(merged[20]), 2)
+        self.assertEqual(merged[20][0], 14)
 
-        return captured, send
+    def test_merge_drops_extra_when_count_decreases(self):
+        """Removing dice keeps the earliest-rolled ones."""
+        merged = roller.merge_rolls({6: [1, 2, 3]}, {6: 1})
+        self.assertEqual(merged[6], [1])
 
-    def test_echo_prepends_input(self):
-        """echo_input prepends the roll string as a '-# ' subtext line."""
-        captured, send = self._capture()
-        asyncio.run(
-            rollcog._do_roll(send, lambda s: "RESULT", "d20 +7", echo_input=True)
-        )
-        self.assertEqual(captured, ["> -# `d20 +7`\nRESULT"])
+    def test_merge_unchanged_counts_reuse_all(self):
+        """When counts don't change, every prior die is reused (e.g. only +N edited)."""
+        merged = roller.merge_rolls({20: [14], 6: [3, 5]}, {20: 1, 6: 2})
+        self.assertEqual(merged[20], [14])
+        self.assertEqual(merged[6], [3, 5])
 
-    def test_no_echo_by_default(self):
-        """Without echo_input the output is unchanged (the text-command case)."""
-        captured, send = self._capture()
-        asyncio.run(rollcog._do_roll(send, lambda s: "RESULT", "d20 +7"))
-        self.assertEqual(captured, ["RESULT"])
-
-    def test_echo_on_error(self):
-        """The echo line is also prepended to a RollError message, then re-raised."""
-        captured, send = self._capture()
-
-        def boom(_):
-            raise roller.RollError("bad dice")
-
-        with self.assertRaises(roller.RollError):
-            asyncio.run(rollcog._do_roll(send, boom, "d99", echo_input=True))
-        self.assertEqual(captured, ["> -# `d99`\nbad dice"])
+    def test_merge_new_size(self):
+        """A newly-added die size is rolled fresh and in range."""
+        merged = roller.merge_rolls({}, {8: 2}, random.Random(5))
+        self.assertEqual(len(merged[8]), 2)
+        for value in merged[8]:
+            self.assertTrue(1 <= value <= 8)
 
 
 class TestEscalation(unittest.TestCase):


### PR DESCRIPTION
Closes #13.

## What & why

Makes editing a roll do something smart: re-run it, reusing the dice that didn't
change and re-rolling only what you added, and update the bot's existing reply in
place (rather than spamming a new one).

## Behavior (text/mention rolls only)

Slash commands are interactions, not editable messages, so this applies to the
`?`/`@mention` forms; slash output is unchanged.

- **Edit in place** — editing your roll message edits the bot's existing reply.
- **Re-roll only added dice** — existing dice are kept; only newly-added dice are
  rolled. Reducing the count keeps a *random* subset of the prior dice (not
  always the first ones). Modifiers (`+N`/`-N`) are always recomputed.
- **Shows what changed** — each prior `Dice:` line is stacked above the new
  result, struck through as small text; multiple edits stack multiple lines:

  ```
  -# ~~Dice: 6d10[10, 8, 3, 4, 8, 7]~~
  Dice: 7d10[10, 8, 3, 4, 8, 7, 7]
  Total: **47**
  ```

- **Stateful commands are safe** — the edit listener only re-runs roll commands
  (`ctx.cog is self`), so editing e.g. `?esc +1` never double-increments.

## Implementation

- `mvkroller.mvkroll`/`plainroll` now return `(text, rolls)` and accept
  `prior_rolls`; `rollcommon.merge_rolls` reuses prior per-size rolls and rolls
  only the delta (random subset when shrinking).
- The `Roll` cog keeps a bounded `RollState(reply, rolls, text, history)` per
  trigger message; `on_message_edit` re-invokes via `bot.get_context`/`invoke`.
  Pure helpers `dice_line`/`render_with_history` build the struck history.

## Verification

- `python test.py` — 35/35 pass (merge reuse + random-keep, dice_line,
  render_with_history, tuple returns, plus the existing suite)
- `ruff check` + `ruff format --check` clean; `pylint` 10.00/10
- Verified live against the dev instance (edit up/down, modifier-only edit,
  multiple edits, and that `?esc` doesn't double-fire).
