### PR TITLE
Add nextround/n shortcut for advancing the escalation die

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
   slash command) shows it; `+1`/`next` advances a round, `-1`/`back` steps down,
   `reset` starts a new battle, and a number `0`–`6` sets it. A channel's value
   resets to 0 after 12 hours of inactivity.
+- `nextround` — shorthand for advancing the escalation die a round (same as
+  `escalation next`). Available as `?nextround`/`/nextround` (text aliases
+  `?next`/`?n`, plus the `/n` slash command).
 - `help` — auto-generated command list and usage. Available as `?help`,
   `@MvkDiceBot help`, or `/help` (optionally pass a command name, e.g.
   `/help command:mvkroll`).

--- a/escalationcog.py
+++ b/escalationcog.py
@@ -163,6 +163,25 @@ class Escalation(commands.Cog):
             interaction.channel_id, action, interaction.response.send_message
         )
 
+    @commands.hybrid_command(name="nextround", aliases=["next", "n"])
+    async def nextround(self, ctx):
+        """Advance the escalation die by a round (same as 'escalation next').
+
+        Usable as '?nextround'/'/nextround' (text aliases '?next', '?n'; also the
+        '/n' slash command).
+        """
+        await self._handle(ctx.channel.id, "next", ctx.reply)
+
+    # As with '/esc', the '/n' slash form is its own command (no slash aliases).
+    @app_commands.command(
+        name="n", description="Advance the escalation die a round (same as /nextround)"
+    )
+    async def n_slash_alias(self, interaction):
+        """Slash-command alias (/n) for /nextround."""
+        await self._handle(
+            interaction.channel_id, "next", interaction.response.send_message
+        )
+
 
 async def setup(bot):
     """discord.py extension entry point: register the Escalation cog."""

--- a/test.py
+++ b/test.py
@@ -272,6 +272,8 @@ class TestBotCommands(unittest.TestCase):
             "justroll": "plainroll",
             "esc": "escalation",
             "e": "escalation",
+            "next": "nextround",
+            "n": "nextround",
         }
         for alias, target in aliases.items():
             with self.subTest(alias=alias):
@@ -282,7 +284,17 @@ class TestBotCommands(unittest.TestCase):
     def test_app_commands_in_tree(self):
         """The commands (incl. /r, /p, /help) are present in the application command tree."""
         app_names = {cmd.name for cmd in mvkdicebot.bot.tree.get_commands()}
-        for name in ("mvkroll", "plainroll", "help", "r", "p", "escalation", "esc"):
+        for name in (
+            "mvkroll",
+            "plainroll",
+            "help",
+            "r",
+            "p",
+            "escalation",
+            "esc",
+            "nextround",
+            "n",
+        ):
             with self.subTest(name=name):
                 self.assertIn(name, app_names)
 


### PR DESCRIPTION
## What & why

Adds a `nextround` shorthand for advancing the 13th Age escalation die a round,
so you don't have to type `escalation next` every round.

- Text: `?nextround`, `?next`, `?n`
- Slash: `/nextround` and `/n`

## Implementation

In `escalationcog.py`: a hybrid `nextround` command (text aliases `next`, `n`)
plus a standalone `/n` `@app_commands.command` (Discord has no slash aliases, so
`/n` is its own command — same pattern as `/esc`). Both reuse the cog's existing
`_handle(channel_id, "next", send)`, so the output matches `escalation next`.

## Verification

- `python test.py` — 35/35 pass (added `nextround`/`n` to the app-tree and alias
  checks)
- `ruff check` + `ruff format --check` clean; `pylint` 10.00/10
- Verified live: `?n`/`?next`/`/n` advance the die and show the new value.
