### PR TITLE
Add critical success, min-impact, stress, counter, modifiers, boost/reduce, burnout to mvkroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
 
 - `mvkroll` — rolls a dice pool and applies the MvK rules math (action total,
   impact, advantage/disadvantage, fumbles, and critical success). Add
-  `overwhelmed`/`staggered` to apply stress (reduce your highest die, or scratch
-  it if both apply), and `vs N` (or `counter N`) to compare your action total
-  against a counter total. Also available as the slash command `/r` (Discord has
+  `overwhelmed`/`staggered` to apply stress (reduces your largest die one size
+  before rolling, or scratches it if both apply), and `vs N` (or `counter N`) to
+  compare your action total against a counter total. Also available as the slash
+  command `/r` (Discord has
   no slash-command aliases, so `/r` is a second command that does the same
   thing).
 - `plainroll` — just rolls dice and adds up `+N`/`-N` modifiers. For a single

--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
 (`/mvkroll dice:1d20 2d10`).
 
 - `mvkroll` — rolls a dice pool and applies the MvK rules math (action total,
-  impact, advantage/disadvantage, fumbles). Also available as the slash command
-  `/r` (Discord has no slash-command aliases, so `/r` is a second command that
-  does the same thing).
+  impact, advantage/disadvantage, fumbles, and critical success). Add
+  `overwhelmed`/`staggered` to apply stress (reduce your highest die, or scratch
+  it if both apply), and `vs N` (or `counter N`) to compare your action total
+  against a counter total. Also available as the slash command `/r` (Discord has
+  no slash-command aliases, so `/r` is a second command that does the same
+  thing).
 - `plainroll` — just rolls dice and adds up `+N`/`-N` modifiers. For a single
   d20 it also calls out 13th Age-flavored results (crit, fumble, even/odd,
   possible two-weapon hit) and, when this channel's escalation die is set, shows

--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
 (`/mvkroll dice:1d20 2d10`).
 
 - `mvkroll` — rolls a dice pool and applies the MvK rules math (action total,
-  impact, advantage/disadvantage, fumbles, and critical success). Add
-  `overwhelmed`/`staggered` to apply stress (reduces your largest die one size
-  before rolling, or scratches it if both apply), and `vs N` (or `counter N`) to
-  compare your action total against a counter total. Also available as the slash
+  impact, advantage/disadvantage, fumbles, and critical success). It also
+  understands several keywords: `overwhelmed`/`staggered` (stress — reduces your
+  largest die one size before rolling, or scratches it if both apply); `vs N`
+  (or `counter N`) to compare your action total against a counter; `+N`/`-N` to
+  adjust the action total and `impact +N` to adjust impact; `boost dN`/`reduce
+  dN` to step a die up/down a size before rolling; `burnout` to total your
+  highest three dice; and the named effects `unstable` (−1 action total) and
+  `burst` (+2 impact, rolled with disadvantage). Also available as the slash
   command `/r` (Discord has
   no slash-command aliases, so `/r` is a second command that does the same
   thing).

--- a/RULES.md
+++ b/RULES.md
@@ -1,3 +1,10 @@
+<!--
+Rules below are verified against the current corebook PDF
+(Mecha_Vs_Kaiju_202X_Corebook.pdf), which supersedes the older
+202X-V1.05 .docx. Quoted lines are from that corebook. The italic
+"_Bot ..._" notes describe what MvKDiceBot actually does.
+-->
+
 # Basic Terminology
 
 These dice are called character dice, because they reflect things about your character that can help you succeed.
@@ -9,8 +16,8 @@ A d20 is known as a fortune die, and it transcends these benchmarks.
 
 # Critical Successes
 
-When you roll a 20 on the fortune die and your action succeeds, it is considered a critical success.
-When you roll a critical success, you can choose to either increase your impact by 2 or gain 1 inspiration point.
+Corebook:
+> When you roll a 20 on the fortune die you use for your total it is considered a critical success. You can choose to either increase your Impact by 2 or gain 1 Inspiration point.
 
 - _Bot calls out a 20 on the kept fortune die as a critical success and notes the +2 impact / 1 inspiration choice._
 
@@ -29,9 +36,8 @@ Whenever you roll a critical fumble, you gain 1 inspiration point.
 
 # Success or Failure
 
-To figure out whether your action succeeds, compare your action total to the opposing counter total.
-If the counter total is higher, you fail; otherwise, your action succeeds.
-**An unsuccessful action cannot inflict stress.**
+Corebook:
+> To figure out whether your action succeeds, compare your action total to the opposing counter total. If the counter total is higher, you fail; otherwise, your action succeeds. A successfully countered action cannot inflict stress.
 
 - _Bot adds up the Action total and displays it; easy for users to compare rolls since it's a simple integer._
 - _Optionally, give the bot a counter total with `vs N` (or `counter N`) and it reports Success/Failure (tie = success). On a failure it notes the action can't inflict stress but still gets minimum impact._
@@ -47,12 +53,10 @@ Character dice that roll 10 or higher generate two impact.
 
 ## Minimum Impact
 
-Your character is highly capable.
-Even if their action is countered, they are still able to accomplish something positive with their action.
-So long as you roll a 4 or higher on your fortune die you still generate a minimum impact of 1.
-You may spend this on any result except causing stress.
+Corebook:
+> Your minimum impact when taking an action is 1, even if the action is successfully countered (so long as the Fortune Die rolled 4 or higher).
 
-- _Bot notes "Minimum impact 1 from the fortune die" when the only impact is the lone point a 4+ fortune die guarantees (the floor that applies even if countered)._
+- _Bot notes "Minimum impact 1 from the fortune die" when the only impact is the lone point a 4+ fortune die guarantees (the floor that applies even if countered). A 4+ fortune die already contributes 1 impact on its own, so the floor only binds when no character die rolled 4+; with a sub-4 fortune die and no qualifying character dice the impact is genuinely 0._
 
 # Advantage and Disadvantage
 
@@ -87,10 +91,21 @@ _Bot enforces this: rolls have 1d20 except for advantage/disadvantage and only 1
 
 # Stress
 
-- Reduce your highest die if you are Overwhelmed OR Staggered.
-- Scratch your highest die if you are Overwhelmed AND Staggered.
+Corebook (Being Overwhelmed or Staggered):
+> If you are Overwhelmed OR Staggered: Reduce the highest die in your pool for all rolls.
+> If you are Overwhelmed AND Staggered: Scratch the highest die in your pool for all rolls.
 
-- _Bot looks for `overwhelmed`/`staggered` in the roll string. One of them reduces the highest character die one size and rerolls it (a d4 is removed); both together scratch the highest character die. The fortune d20 is never touched._
+Corebook quick reference clarifies "highest die" as the highest die **type**:
+> Overwhelmed. ... Reduce the highest die type in your pool.
+> Staggered. ... Reduce the highest die type in your pool.
+> Overwhelmed+Staggered. Scratch the highest die type in your pool.
+
+(The older .docx was self-contradictory here — one passage said the
+Overwhelmed-AND-Staggered case was "reduce, then drop the highest die result
+from your total." The corebook settles it: that case is simply "scratch," and
+"highest die" means highest die _type_, i.e. size.)
+
+- _Bot looks for `overwhelmed`/`staggered` in the roll string and adjusts the pool **before rolling**: one of them reduces the largest character die type one size (d12→d10→…→d4, and a d4 is removed); both together scratch the largest character die type. The fortune d20 is never reduced/scratched (the rules never boost/reduce the fortune die)._
 
 # Impact Total
 
@@ -98,3 +113,26 @@ Count how many dice rolled 4+ for your Impact
 Minimum 1 Impact if your fortune die rolled 4+, even if your action was countered.
 
 _Bot calculates this and notes the minimum-impact-1 case. It only knows an action was countered if you give it a counter total (`vs N`)._
+
+# Boost / Reduce (pool building)
+
+Corebook:
+> The rules sometimes tell you to boost a die, changing it from a die of one size to one of a larger size ... or to reduce a die (the reverse...). When you boost a d12 in your dice pool, you keep the d12, but add an extra d4 to your pool as well. When you reduce a d4 in your pool, you remove that die entirely. You never boost the Fortune die up or down, and no other die size can boost to a d20.
+
+_Bot does not implement boost/reduce as a roll keyword — you just type the dice you end up with. (The stress feature reuses the "reduce" definition internally.)_
+
+# Other dice mechanics found in the corebook (not automated)
+
+These exist but are tied to specific character abilities/perks/powers, so they're
+too character-specific for the bot to apply automatically — the player just adds
+or removes the relevant dice/modifiers themselves before rolling:
+
+- Perk "Dice": "Add a d6 to your dice pool. • Boost a die that helps you. • Double a specific trait die in your pool. • Reduce a die that opposes you. • Reroll your dice pool."
+- Perk "Impact": "Add 2 points of impact towards a specific outcome."
+- "Burst": "Double your Drive die and add +2 Impact ... roll one additional fortune die ... but the highest-rolling d20 in your pool is scratched." (i.e. disadvantage)
+- "Burn Out": "Add three dice to determine your action total" (the only case where more than two dice are summed).
+- "Unstable": "Apply a cumulative -1 modifier to your action total each time this is used."
+- Spend Inspiration: before rolling, add a trait die or roll with Advantage; after rolling, add an unused die to your total / use one as an extra impact.
+- "Blowback": "If you roll a 1 on any die in your pool the GM may immediately reroll that and use it as an Impact die on you or an ally."
+
+_Note: `mvkroll` has no `+N`/`-N` action-total modifier (only `plainroll` does math today), even though several abilities above grant flat modifiers — a possible future addition._

--- a/RULES.md
+++ b/RULES.md
@@ -12,7 +12,7 @@ A d20 is known as a fortune die, and it transcends these benchmarks.
 When you roll a 20 on the fortune die and your action succeeds, it is considered a critical success.
 When you roll a critical success, you can choose to either increase your impact by 2 or gain 1 inspiration point.
 
-_Bot calls out a 20 as crit success_
+- _Bot calls out a 20 on the kept fortune die as a critical success and notes the +2 impact / 1 inspiration choice._
 
 # Critical Fumble
 
@@ -33,8 +33,8 @@ To figure out whether your action succeeds, compare your action total to the opp
 If the counter total is higher, you fail; otherwise, your action succeeds.
 **An unsuccessful action cannot inflict stress.**
 
-- _Bot doesn't really do anything with this. Doesn't differentiate action vs counter._
-- _Bot _does_ add up the Action total and display that. Easy for users to compare rolls since action total is simple integer._
+- _Bot adds up the Action total and displays it; easy for users to compare rolls since it's a simple integer._
+- _Optionally, give the bot a counter total with `vs N` (or `counter N`) and it reports Success/Failure (tie = success). On a failure it notes the action can't inflict stress but still gets minimum impact._
 
 # Impact
 
@@ -52,7 +52,7 @@ Even if their action is countered, they are still able to accomplish something p
 So long as you roll a 4 or higher on your fortune die you still generate a minimum impact of 1.
 You may spend this on any result except causing stress.
 
-- _TODO: Maybe include note about minimum impact whenever fortune die is >=4?_
+- _Bot notes "Minimum impact 1 from the fortune die" when the only impact is the lone point a 4+ fortune die guarantees (the floor that applies even if countered)._
 
 # Advantage and Disadvantage
 
@@ -77,7 +77,7 @@ In some situations (such as when you have taken too much stress), the rules requ
 This is done after you roll your dice pool.
 Once all the dice are rolled, a scratched die is removed from your roll entirely, and cannot be used for your action total or your impact—it’s as if it was never part of your pool at all.
 
-_Bot doesn't scratch die except in case of critical fumble via d20 rolling a 1._
+_Bot scratches a die on a critical fumble (d20 rolling a 1) and for Overwhelmed+Staggered stress (see Stress, below)._
 
 # The Limits of Fortune
 
@@ -90,11 +90,11 @@ _Bot enforces this: rolls have 1d20 except for advantage/disadvantage and only 1
 - Reduce your highest die if you are Overwhelmed OR Staggered.
 - Scratch your highest die if you are Overwhelmed AND Staggered.
 
-_TODO: look for overwhelmed, staggered or both in roll string and do this automatically for the user?_
+- _Bot looks for `overwhelmed`/`staggered` in the roll string. One of them reduces the highest character die one size and rerolls it (a d4 is removed); both together scratch the highest character die. The fortune d20 is never touched._
 
 # Impact Total
 
 Count how many dice rolled 4+ for your Impact
 Minimum 1 Impact if your fortune die rolled 4+, even if your action was countered.
 
-_Bot calculates this. Except doesn't display minimum impact rule. Doesn't know if action was countered._
+_Bot calculates this and notes the minimum-impact-1 case. It only knows an action was countered if you give it a counter total (`vs N`)._

--- a/RULES.md
+++ b/RULES.md
@@ -119,20 +119,19 @@ _Bot calculates this and notes the minimum-impact-1 case. It only knows an actio
 Corebook:
 > The rules sometimes tell you to boost a die, changing it from a die of one size to one of a larger size ... or to reduce a die (the reverse...). When you boost a d12 in your dice pool, you keep the d12, but add an extra d4 to your pool as well. When you reduce a d4 in your pool, you remove that die entirely. You never boost the Fortune die up or down, and no other die size can boost to a d20.
 
-_Bot does not implement boost/reduce as a roll keyword — you just type the dice you end up with. (The stress feature reuses the "reduce" definition internally.)_
+- _Bot supports `boost dN` / `reduce dN` keywords that apply this before rolling: boost steps a die up one size (boosting a d12 keeps it and adds a d4); reduce steps it down (reducing a d4 removes it). The die must already be in the pool, and the fortune d20 is never boosted/reduced. (You can also just type the dice you end up with.)_
 
-# Other dice mechanics found in the corebook (not automated)
+# Ability-driven dice mechanics from the corebook
 
-These exist but are tied to specific character abilities/perks/powers, so they're
-too character-specific for the bot to apply automatically — the player just adds
-or removes the relevant dice/modifiers themselves before rolling:
+These come from specific character abilities/perks/powers. The bot now automates
+the parts that are pure dice math (via keywords); anything that requires knowing
+which of your dice is the "Drive die" etc. is left to the player.
 
-- Perk "Dice": "Add a d6 to your dice pool. • Boost a die that helps you. • Double a specific trait die in your pool. • Reduce a die that opposes you. • Reroll your dice pool."
-- Perk "Impact": "Add 2 points of impact towards a specific outcome."
-- "Burst": "Double your Drive die and add +2 Impact ... roll one additional fortune die ... but the highest-rolling d20 in your pool is scratched." (i.e. disadvantage)
-- "Burn Out": "Add three dice to determine your action total" (the only case where more than two dice are summed).
-- "Unstable": "Apply a cumulative -1 modifier to your action total each time this is used."
-- Spend Inspiration: before rolling, add a trait die or roll with Advantage; after rolling, add an unused die to your total / use one as an extra impact.
-- "Blowback": "If you roll a 1 on any die in your pool the GM may immediately reroll that and use it as an Impact die on you or an ally."
-
-_Note: `mvkroll` has no `+N`/`-N` action-total modifier (only `plainroll` does math today), even though several abilities above grant flat modifiers — a possible future addition._
+- Flat modifiers — _Bot: `+N`/`-N` adjust the **action total**; `impact +N` (or `+N impact`) adjusts **impact**. (MvK is mostly a dice-not-modifiers system; these cover the rare flat bonuses.)_
+- Perk "Dice": "Add a d6 to your dice pool. • Boost a die that helps you. • Double a specific trait die in your pool. • Reduce a die that opposes you. • Reroll your dice pool." — _Bot: boost/reduce are keywords (see Boost/Reduce); add/double a die by just typing it; reroll by rolling again._
+- Perk "Impact": "Add 2 points of impact towards a specific outcome." — _Bot: `impact +2`._
+- "Unstable": "Apply a cumulative -1 modifier to your action total each time this is used." — _Bot: `unstable` keyword applies -1 (the per-use stacking is up to you — repeat the keyword or use `-N`)._
+- "Burst": "Double your Drive die and add +2 Impact ... roll one additional fortune die ... but the highest-rolling d20 in your pool is scratched." — _Bot: `burst` keyword adds +2 impact and rolls with disadvantage; add the doubled Drive die yourself._
+- "Burn Out": "Add three dice to determine your action total." — _Bot: `burnout` keyword totals the highest three dice (the extra trait dice are added by you)._
+- Spend Inspiration: before rolling, add a trait die or roll with Advantage; after rolling, add an unused die to your total / use one as an extra impact. — _Not automated; add the die or use `advantage`._
+- "Blowback": "If you roll a 1 on any die in your pool the GM may immediately reroll that and use it as an Impact die on you or an ally." — _Not automated (GM-side)._

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -39,6 +39,7 @@ from rollcommon import (
 )
 from rollmvkhelpers import (
     adv_disadv,
+    boost_reduce,
     calc_action,
     calc_impact,
     compare_counter,
@@ -51,28 +52,86 @@ from rollplainhelpers import parse_math, print_d20_special
 
 logger = logging.getLogger(__name__)
 
+# Tokens that look like dice (``boost d8`` / ``reduce d4``) but name a target for
+# a keyword rather than a die to roll; stripped before the pool is parsed.
+BOOST_REDUCE_RE = re.compile(r"\b(?:boost|reduce)\s*d[0-9]+", flags=re.IGNORECASE)
+
 # Roll-string modifiers mvkroll understands beyond the dice themselves.
 Modifiers = collections.namedtuple(
-    "Modifiers", "advantage disadvantage overwhelmed staggered counter"
+    "Modifiers",
+    "advantage disadvantage overwhelmed staggered counter "
+    "action_mod impact_mod boosts reduces burnout",
 )
 
 
-def _parse_modifiers(dicestr):
-    """Pull advantage/disadvantage, stress, and an optional counter from the string.
+def _impact_modifier(dicestr):
+    """Sum ``impact +N`` / ``+N impact`` modifiers and return (total, leftover_text).
 
-    "disadvantage" contains "advantage", so disadvantage wins when both appear
-    (matching the rules: advantage and disadvantage cancel out, and a lone
-    disadvantage must not also register as advantage).
+    The matched substrings are blanked out of the returned text so the remaining
+    +/- numbers can be read as action-total modifiers without double counting.
     """
-    disadvantage = bool(re.search(r"disadvantage", dicestr, flags=re.IGNORECASE))
+    impact_mod = 0
+    text = dicestr
+    # Match "+N impact" (number before) before "impact +N" (number after), so a
+    # string like "+2 impact -1" reads as +2 impact and -1 action, not -1 impact.
+    for pattern in (r"([+-])\s*([0-9]+)\s*impact", r"impact\s*([+-])\s*([0-9]+)"):
+        for sign, num in re.findall(pattern, text, flags=re.IGNORECASE):
+            impact_mod += int(sign + num)
+        text = re.sub(pattern, " ", text, flags=re.IGNORECASE)
+    return impact_mod, text
+
+
+def _parse_modifiers(dicestr):
+    """Pull every non-dice modifier mvkroll understands out of the roll string.
+
+    Recognizes advantage/disadvantage, Overwhelmed/Staggered stress, an optional
+    counter (``vs N``), flat action-total (`+N`/`-N`) and impact (``impact +N``)
+    modifiers, ``boost dN``/``reduce dN``, ``burnout``, and the named effects
+    ``unstable`` (-1 action total) and ``burst`` (+2 impact, with disadvantage).
+    """
+    unstable = bool(re.search(r"\bunstable\b", dicestr, flags=re.IGNORECASE))
+    burst = bool(re.search(r"\bburst\b", dicestr, flags=re.IGNORECASE))
+
+    # "disadvantage" contains "advantage", so disadvantage wins when both appear
+    # (advantage and disadvantage cancel). Burst is rolled with disadvantage.
+    disadvantage = (
+        bool(re.search(r"disadvantage", dicestr, flags=re.IGNORECASE)) or burst
+    )
     advantage = (
         bool(re.search(r"advantage", dicestr, flags=re.IGNORECASE)) and not disadvantage
     )
+
     overwhelmed = bool(re.search(r"overwhelmed", dicestr, flags=re.IGNORECASE))
     staggered = bool(re.search(r"staggered", dicestr, flags=re.IGNORECASE))
     match = re.search(r"(?:vs|counter)\s*([0-9]+)", dicestr, flags=re.IGNORECASE)
     counter = int(match.group(1)) if match else None
-    return Modifiers(advantage, disadvantage, overwhelmed, staggered, counter)
+
+    impact_mod, leftover = _impact_modifier(dicestr)
+    if burst:
+        impact_mod += 2
+    # Bare +/- numbers left after impact mods are removed adjust the action total.
+    action_mod = parse_math(leftover) - (1 if unstable else 0)
+
+    boosts = [
+        int(s) for s in re.findall(r"boost\s*d([0-9]+)", dicestr, flags=re.IGNORECASE)
+    ]
+    reduces = [
+        int(s) for s in re.findall(r"reduce\s*d([0-9]+)", dicestr, flags=re.IGNORECASE)
+    ]
+    burnout = bool(re.search(r"\bburn\s*out\b", dicestr, flags=re.IGNORECASE))
+
+    return Modifiers(
+        advantage,
+        disadvantage,
+        overwhelmed,
+        staggered,
+        counter,
+        action_mod,
+        impact_mod,
+        boosts,
+        reduces,
+        burnout,
+    )
 
 
 def mvkroll(dicestr: str, prior_rolls=None):
@@ -89,7 +148,9 @@ def mvkroll(dicestr: str, prior_rolls=None):
     answer = ""
     mods = _parse_modifiers(dicestr)
 
-    dicecounts = parse_dice(dicestr)
+    # Drop "boost dN"/"reduce dN" tokens so their target die isn't read as a die
+    # to roll; the boost/reduce itself is applied from mods below.
+    dicecounts = parse_dice(BOOST_REDUCE_RE.sub(" ", dicestr))
 
     # advantage and disadvantage need _at least_ 2d20
     # everything else only gets 1d20
@@ -101,10 +162,11 @@ def mvkroll(dicestr: str, prior_rolls=None):
         dicecounts[20] = 1
         answer += "_No advantage/disadvantage, setting 1d20_\n"
 
-    # Stress reduces/scratches the highest character die *type* before rolling.
-    stress_answer, dicecounts = stress_adjust(
-        dicecounts, mods.overwhelmed, mods.staggered
-    )
+    # Pool changes happen before rolling: boost/reduce keywords, then stress
+    # (which reduces/scratches the highest remaining character die *type*). Both
+    # mutate dicecounts in place; we keep only their note text.
+    answer += boost_reduce(dicecounts, mods.boosts, mods.reduces)[0]
+    answer += stress_adjust(dicecounts, mods.overwhelmed, mods.staggered)[0]
 
     if prior_rolls is None:
         dicerolls = roll_dice(dicecounts)
@@ -125,8 +187,6 @@ def mvkroll(dicestr: str, prior_rolls=None):
     )
     answer += adv_disadv_answer
 
-    # Note any stress change, then show the (already stress-adjusted) pool.
-    answer += stress_answer
     answer += print_dice(dicerolls)
     answer += "\n"
 
@@ -152,11 +212,19 @@ def mvkroll(dicestr: str, prior_rolls=None):
 
     answer += crit_success(fortunedicerolls)
 
-    action_answer, action_total = calc_action(fortunedicerolls, characterdicerolls)
+    # Burn Out totals the highest three dice instead of two.
+    action_answer, action_total = calc_action(
+        fortunedicerolls,
+        characterdicerolls,
+        keep=3 if mods.burnout else 2,
+        modifier=mods.action_mod,
+    )
     answer += action_answer
     answer += compare_counter(action_total, mods.counter)
 
-    answer += calc_impact(fortunedicerolls, characterdicerolls)
+    answer += calc_impact(
+        fortunedicerolls, characterdicerolls, modifier=mods.impact_mod
+    )
 
     return answer, rolls
 

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -25,6 +25,7 @@ rolling, and display), rollmvkhelpers (MvK rules math), and rollplainhelpers
 can keep using ``mvkroller.RollError`` / ``mvkroller.parse_dice``.
 """
 
+import collections
 import logging
 import re
 
@@ -40,12 +41,38 @@ from rollmvkhelpers import (
     adv_disadv,
     calc_action,
     calc_impact,
+    compare_counter,
     crit_fumble,
+    crit_success,
     possible_fumble,
+    stress_adjust,
 )
 from rollplainhelpers import parse_math, print_d20_special
 
 logger = logging.getLogger(__name__)
+
+# Roll-string modifiers mvkroll understands beyond the dice themselves.
+Modifiers = collections.namedtuple(
+    "Modifiers", "advantage disadvantage overwhelmed staggered counter"
+)
+
+
+def _parse_modifiers(dicestr):
+    """Pull advantage/disadvantage, stress, and an optional counter from the string.
+
+    "disadvantage" contains "advantage", so disadvantage wins when both appear
+    (matching the rules: advantage and disadvantage cancel out, and a lone
+    disadvantage must not also register as advantage).
+    """
+    disadvantage = bool(re.search(r"disadvantage", dicestr, flags=re.IGNORECASE))
+    advantage = (
+        bool(re.search(r"advantage", dicestr, flags=re.IGNORECASE)) and not disadvantage
+    )
+    overwhelmed = bool(re.search(r"overwhelmed", dicestr, flags=re.IGNORECASE))
+    staggered = bool(re.search(r"staggered", dicestr, flags=re.IGNORECASE))
+    match = re.search(r"(?:vs|counter)\s*([0-9]+)", dicestr, flags=re.IGNORECASE)
+    counter = int(match.group(1)) if match else None
+    return Modifiers(advantage, disadvantage, overwhelmed, staggered, counter)
 
 
 def mvkroll(dicestr: str, prior_rolls=None):
@@ -60,19 +87,13 @@ def mvkroll(dicestr: str, prior_rolls=None):
     logger.debug("Roll %s", {dicestr})
 
     answer = ""
-    advantage = False
-    disadvantage = False
-
-    if re.search(r"disadvantage", dicestr, flags=re.IGNORECASE):
-        disadvantage = True
-    elif re.search(r"advantage", dicestr, flags=re.IGNORECASE):
-        advantage = True
+    mods = _parse_modifiers(dicestr)
 
     dicecounts = parse_dice(dicestr)
 
     # advantage and disadvantage need _at least_ 2d20
     # everything else only gets 1d20
-    if advantage or disadvantage:
+    if mods.advantage or mods.disadvantage:
         if dicecounts[20] < 2:
             dicecounts[20] = 2
             answer += "_Setting 2d20 for advantage/disadvantage_\n"
@@ -94,8 +115,21 @@ def mvkroll(dicestr: str, prior_rolls=None):
     fortunedicerolls.sort(reverse=True)
     logger.debug("fortune rolls %s", fortunedicerolls)
 
-    # dice d4-d12 are called "Character Dice"
-    # Grab all the values from all the rolls that weren't d20s
+    adv_disadv_answer, fortunedicerolls = adv_disadv(
+        mods.advantage, mods.disadvantage, dicecounts, dicerolls
+    )
+    answer += adv_disadv_answer
+
+    # Show the pool as rolled, then let stress reduce/scratch the highest die.
+    answer += print_dice(dicerolls)
+    answer += "\n"
+
+    stress_answer, dicerolls = stress_adjust(
+        dicerolls, mods.overwhelmed, mods.staggered
+    )
+    answer += stress_answer
+
+    # dice d4-d12 are called "Character Dice"; grab them after any stress change
     characterdicerolls = [
         val for (key, rollset) in dicerolls.items() if key != 20 for val in rollset
     ]
@@ -104,14 +138,6 @@ def mvkroll(dicestr: str, prior_rolls=None):
 
     if len(characterdicerolls) + len(fortunedicerolls) < 1:
         raise RollError("Not enough dice to roll")
-
-    adv_disadv_answer, fortunedicerolls = adv_disadv(
-        advantage, disadvantage, dicecounts, dicerolls
-    )
-    answer += adv_disadv_answer
-
-    answer += print_dice(dicerolls)
-    answer += "\n"
 
     possible_fumble_answer = possible_fumble(fortunedicerolls)
 
@@ -123,7 +149,11 @@ def mvkroll(dicestr: str, prior_rolls=None):
     elif possible_fumble_answer:
         answer += possible_fumble_answer
 
-    answer += calc_action(fortunedicerolls, characterdicerolls)
+    answer += crit_success(fortunedicerolls)
+
+    action_answer, action_total = calc_action(fortunedicerolls, characterdicerolls)
+    answer += action_answer
+    answer += compare_counter(action_total, mods.counter)
 
     answer += calc_impact(fortunedicerolls, characterdicerolls)
 

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -101,6 +101,11 @@ def mvkroll(dicestr: str, prior_rolls=None):
         dicecounts[20] = 1
         answer += "_No advantage/disadvantage, setting 1d20_\n"
 
+    # Stress reduces/scratches the highest character die *type* before rolling.
+    stress_answer, dicecounts = stress_adjust(
+        dicecounts, mods.overwhelmed, mods.staggered
+    )
+
     if prior_rolls is None:
         dicerolls = roll_dice(dicecounts)
     else:
@@ -120,16 +125,12 @@ def mvkroll(dicestr: str, prior_rolls=None):
     )
     answer += adv_disadv_answer
 
-    # Show the pool as rolled, then let stress reduce/scratch the highest die.
+    # Note any stress change, then show the (already stress-adjusted) pool.
+    answer += stress_answer
     answer += print_dice(dicerolls)
     answer += "\n"
 
-    stress_answer, dicerolls = stress_adjust(
-        dicerolls, mods.overwhelmed, mods.staggered
-    )
-    answer += stress_answer
-
-    # dice d4-d12 are called "Character Dice"; grab them after any stress change
+    # dice d4-d12 are called "Character Dice"
     characterdicerolls = [
         val for (key, rollset) in dicerolls.items() if key != 20 for val in rollset
     ]

--- a/rollcog.py
+++ b/rollcog.py
@@ -30,7 +30,8 @@ import mvkroller
 # Slash-command parameter descriptions, shared by the hybrid commands and their
 # /r and /p slash aliases so the help text stays identical.
 MVK_DICE_HELP = (
-    "Dice to roll, e.g. '1d20 2d10 d8 2d6'. Add 'advantage'/'disadvantage' for the d20."
+    "Dice, e.g. '1d20 2d10 d8 2d6'. Add 'advantage'/'disadvantage', "
+    "'overwhelmed'/'staggered' (stress), or 'vs N' to compare a counter total."
 )
 PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
 
@@ -153,6 +154,11 @@ class Roll(commands.Cog):
         Add 'disadvantage' to discard highest d20.
         Example: '?roll 2d20 2d10 advantage'
         Example: '?roll 2d20 2d10 disadvantage'
+
+        Add 'overwhelmed' or 'staggered' (stress) to reduce your highest die; both
+        together scratch it instead.
+        Add 'vs N' (or 'counter N') to compare your action total to a counter.
+        Example: '?roll 1d20 2d10 overwhelmed vs 21'
 
         Ignores anything extra it doesn't understand. Editing a text roll re-rolls
         only the dice you added and updates the same reply.

--- a/rollcog.py
+++ b/rollcog.py
@@ -155,8 +155,8 @@ class Roll(commands.Cog):
         Example: '?roll 2d20 2d10 advantage'
         Example: '?roll 2d20 2d10 disadvantage'
 
-        Add 'overwhelmed' or 'staggered' (stress) to reduce your highest die; both
-        together scratch it instead.
+        Add 'overwhelmed' or 'staggered' (stress) to reduce your largest die one
+        size before rolling; both together scratch it instead.
         Add 'vs N' (or 'counter N') to compare your action total to a counter.
         Example: '?roll 1d20 2d10 overwhelmed vs 21'
 

--- a/rollcog.py
+++ b/rollcog.py
@@ -30,8 +30,8 @@ import mvkroller
 # Slash-command parameter descriptions, shared by the hybrid commands and their
 # /r and /p slash aliases so the help text stays identical.
 MVK_DICE_HELP = (
-    "Dice, e.g. '1d20 2d10 d8 2d6'. Add 'advantage'/'disadvantage', "
-    "'overwhelmed'/'staggered' (stress), or 'vs N' to compare a counter total."
+    "Dice + keywords: advantage/disadvantage, overwhelmed/staggered, "
+    "boost/reduce dN, burnout, unstable, burst, +N, impact+N, vs N (see ?help)."
 )
 PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
 
@@ -159,6 +159,14 @@ class Roll(commands.Cog):
         size before rolling; both together scratch it instead.
         Add 'vs N' (or 'counter N') to compare your action total to a counter.
         Example: '?roll 1d20 2d10 overwhelmed vs 21'
+
+        More keywords:
+        - '+N'/'-N' adjust the action total; 'impact +N' adjusts impact.
+        - 'boost dN'/'reduce dN' step a die up/down a size before rolling
+          (boosting a d12 adds a d4; reducing a d4 removes it).
+        - 'burnout' totals your highest three dice instead of two.
+        - 'unstable' applies -1 to the action total; 'burst' adds +2 impact and
+          rolls with disadvantage (add the doubled Drive die yourself).
 
         Ignores anything extra it doesn't understand. Editing a text roll re-rolls
         only the dice you added and updates the same reply.

--- a/rollmvkhelpers.py
+++ b/rollmvkhelpers.py
@@ -20,14 +20,13 @@
 """Helpers specific to the MvK ruleset roller (mvkroll)."""
 
 import logging
-import random
 
-from rollcommon import RollError, _roll_one
+from rollcommon import RollError
 
 logger = logging.getLogger(__name__)
 
-# Die sizes a character die can be reduced to, in order (the fortune d20 is
-# never reduced). Reducing a d4 drops it from the pool entirely.
+# The next-smaller size a character die reduces to (the fortune d20 is never
+# reduced). Reducing a d4 drops it from the pool entirely.
 _SMALLER_SIZE = {12: 10, 10: 8, 8: 6, 6: 4, 4: None}
 
 
@@ -178,61 +177,42 @@ def compare_counter(action_total, counter):
     )
 
 
-def _highest_character_die(dicerolls):
-    """(size, value) of the highest-result character die, or None if there are none.
+def stress_adjust(dicecounts, overwhelmed, staggered):
+    """Apply Overwhelmed/Staggered stress to the dice pool *before* it is rolled.
 
-    Ties on value are broken toward the larger die size.
-    """
-    best = None  # (value, size)
-    for size, values in dicerolls.items():
-        if size == 20:
-            continue
-        for value in values:
-            if best is None or (value, size) > best:
-                best = (value, size)
-    if best is None:
-        return None
-    value, size = best
-    return size, value
-
-
-def stress_adjust(dicerolls, overwhelmed, staggered, rand_source=None):
-    """Apply 13th-Age-style stress to the pool, mutating ``dicerolls`` in place.
-
-    Overwhelmed OR Staggered reduces the highest character die one size and
-    rerolls it (a d4 is removed outright); Overwhelmed AND Staggered scratches
-    the highest character die instead. The fortune d20 is never touched. Returns
-    ``(answer, dicerolls)``; the answer is empty when neither condition applies.
+    Stress targets the largest character die in the pool (the fortune d20 is
+    never reduced). Overwhelmed OR Staggered reduces that die one size, so it is
+    then rolled at the smaller size (a d4 is removed from the pool entirely);
+    Overwhelmed AND Staggered scratches it (removed before any roll, per the
+    rulebook's "scratch the highest die in your pool before making any roll").
+    Mutates and returns ``(answer, dicecounts)``; the answer is empty when
+    neither condition applies.
     """
     if not (overwhelmed or staggered):
-        return "", dicerolls
+        return "", dicecounts
 
     try:
-        highest = _highest_character_die(dicerolls)
-        if highest is None:
-            return "**Stress**\n-# No character dice to reduce.\n", dicerolls
+        size = next((s for s in (12, 10, 8, 6, 4) if dicecounts.get(s, 0) > 0), None)
+        if size is None:
+            return "**Stress**\n-# No character dice to reduce.\n", dicecounts
 
-        size, value = highest
-        dicerolls[size].remove(value)
+        dicecounts[size] -= 1
 
         if overwhelmed and staggered:
             return (
-                f"**Stress: Overwhelmed & Staggered**\n*Scratched highest die: {value}*\n",
-                dicerolls,
+                f"**Stress: Overwhelmed & Staggered**\n*Scratched highest die: d{size}*\n",
+                dicecounts,
             )
 
-        if rand_source is None:
-            rand_source = random.Random()
         smaller = _SMALLER_SIZE[size]
         if smaller is None:
-            detail = f"d{size}[{value}] → removed"
+            detail = f"d{size} → removed"
         else:
-            new_value = _roll_one(smaller, rand_source)
-            dicerolls[smaller].append(new_value)
-            detail = f"d{size}[{value}] → d{smaller}[{new_value}]"
+            dicecounts[smaller] += 1
+            detail = f"d{size} → d{smaller}"
         return (
             f"**Stress: Overwhelmed/Staggered**\n*Reduced highest die: {detail}*\n",
-            dicerolls,
+            dicecounts,
         )
     except Exception as exc:
         raise RollError("Coding error applying stress.") from exc

--- a/rollmvkhelpers.py
+++ b/rollmvkhelpers.py
@@ -20,10 +20,15 @@
 """Helpers specific to the MvK ruleset roller (mvkroll)."""
 
 import logging
+import random
 
-from rollcommon import RollError
+from rollcommon import RollError, _roll_one
 
 logger = logging.getLogger(__name__)
+
+# Die sizes a character die can be reduced to, in order (the fortune d20 is
+# never reduced). Reducing a d4 drops it from the pool entirely.
+_SMALLER_SIZE = {12: 10, 10: 8, 8: 6, 6: 4, 4: None}
 
 
 def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
@@ -53,33 +58,51 @@ def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
 
 
 def calc_action(fortunedicerolls, characterdicerolls):
-    """Compute the action total, using the highest two rolls. Up to one fortune die may be used."""
+    """Compute the action total, using the highest two rolls. Up to one fortune die may be used.
+
+    Returns ``(answer, action_total)`` so callers can compare the numeric total
+    against an opposing counter total.
+    """
     try:
         action_dice = sorted(fortunedicerolls, reverse=True)[:1]
         action_dice += characterdicerolls
         action_dice.sort(reverse=True)
         action_dice = action_dice[:2]
-        answer = f"**Action Total: {str(sum(action_dice))}** {str(action_dice)}\n"
+        action_total = sum(action_dice)
+        answer = f"**Action Total: {str(action_total)}** {str(action_dice)}\n"
     except Exception as exc:
         raise RollError(
             "Coding error flattening dice rolls and creating total."
         ) from exc
-    return answer
+    return answer, action_total
 
 
 def calc_impact(fortunedicerolls, characterdicerolls):
     """Calculate the impact total"""
     try:
         # die results of 10 or higher on a d10 or 12 give two impact. It doesn't happen on a d20.
-        fortuneimpact = 1 if fortunedicerolls[0] >= 4 else 0
+        fortune_high = fortunedicerolls[0] >= 4
+        fortuneimpact = 1 if fortune_high else 0
         doublecharacterimpact = sum(2 for p in characterdicerolls if p >= 10)
         characterimpact = sum(1 for p in characterdicerolls if 4 <= p < 10)
-        impact = fortuneimpact + doublecharacterimpact + characterimpact
-        impact = max(impact, 1)
+        raw = fortuneimpact + doublecharacterimpact + characterimpact
+        # Minimum impact of 1, but only when the fortune die rolled 4+ (even a
+        # countered action still accomplishes something). With no 4+ fortune die
+        # and no qualifying character dice the impact is genuinely 0.
+        impact = max(raw, 1) if fortune_high else raw
         answer = f"**Impact: {impact}** "
         answer += (
             f"(fortune={fortuneimpact} 2x={doublecharacterimpact} 1x={characterimpact})"
         )
+        # When that lone point comes only from the fortune die, it's the minimum
+        # impact you keep even if the action is countered -- worth spelling out.
+        if (
+            impact == 1
+            and fortuneimpact == 1
+            and not doublecharacterimpact
+            and not characterimpact
+        ):
+            answer += "\n-# Minimum impact 1 from the fortune die (even if countered)."
     except Exception as exc:
         raise RollError("Coding error calculating Impact") from exc
     return answer
@@ -121,3 +144,95 @@ def possible_fumble(fortunedicerolls):
             "If your action is successfully countered, gain 1 inspiration point.\n"
         )
     return answer
+
+
+def crit_success(fortunedicerolls):
+    """A 20 on the fortune die used for the total is a critical success.
+
+    ``fortunedicerolls`` is sorted descending and (after advantage/disadvantage)
+    holds the single kept die, so index 0 is the die used for the action total.
+    A critical success and a critical fumble can't both happen on that one die.
+    """
+    if fortunedicerolls and fortunedicerolls[0] == 20:
+        return (
+            "**Critical Success**\n"
+            "Choose: increase your Impact by 2, or gain 1 inspiration point.\n"
+        )
+    return ""
+
+
+def compare_counter(action_total, counter):
+    """Compare the action total to an optional counter total (None = skip).
+
+    Per the rules, the action succeeds unless the counter total is *higher*, so
+    a tie is a success. An unsuccessful action can't inflict stress, but the
+    actor still gets their minimum impact, so we say so rather than zeroing it.
+    """
+    if counter is None:
+        return ""
+    if action_total >= counter:
+        return f"**Success!** (Action {action_total} vs Counter {counter})\n"
+    return (
+        f"**Failure** (Action {action_total} vs Counter {counter})\n"
+        "-# Countered: cannot inflict stress; minimum impact still applies.\n"
+    )
+
+
+def _highest_character_die(dicerolls):
+    """(size, value) of the highest-result character die, or None if there are none.
+
+    Ties on value are broken toward the larger die size.
+    """
+    best = None  # (value, size)
+    for size, values in dicerolls.items():
+        if size == 20:
+            continue
+        for value in values:
+            if best is None or (value, size) > best:
+                best = (value, size)
+    if best is None:
+        return None
+    value, size = best
+    return size, value
+
+
+def stress_adjust(dicerolls, overwhelmed, staggered, rand_source=None):
+    """Apply 13th-Age-style stress to the pool, mutating ``dicerolls`` in place.
+
+    Overwhelmed OR Staggered reduces the highest character die one size and
+    rerolls it (a d4 is removed outright); Overwhelmed AND Staggered scratches
+    the highest character die instead. The fortune d20 is never touched. Returns
+    ``(answer, dicerolls)``; the answer is empty when neither condition applies.
+    """
+    if not (overwhelmed or staggered):
+        return "", dicerolls
+
+    try:
+        highest = _highest_character_die(dicerolls)
+        if highest is None:
+            return "**Stress**\n-# No character dice to reduce.\n", dicerolls
+
+        size, value = highest
+        dicerolls[size].remove(value)
+
+        if overwhelmed and staggered:
+            return (
+                f"**Stress: Overwhelmed & Staggered**\n*Scratched highest die: {value}*\n",
+                dicerolls,
+            )
+
+        if rand_source is None:
+            rand_source = random.Random()
+        smaller = _SMALLER_SIZE[size]
+        if smaller is None:
+            detail = f"d{size}[{value}] → removed"
+        else:
+            new_value = _roll_one(smaller, rand_source)
+            dicerolls[smaller].append(new_value)
+            detail = f"d{size}[{value}] → d{smaller}[{new_value}]"
+        return (
+            f"**Stress: Overwhelmed/Staggered**\n*Reduced highest die: {detail}*\n",
+            dicerolls,
+        )
+    except Exception as exc:
+        raise RollError("Coding error applying stress.") from exc

--- a/rollmvkhelpers.py
+++ b/rollmvkhelpers.py
@@ -28,6 +28,9 @@ logger = logging.getLogger(__name__)
 # The next-smaller size a character die reduces to (the fortune d20 is never
 # reduced). Reducing a d4 drops it from the pool entirely.
 _SMALLER_SIZE = {12: 10, 10: 8, 8: 6, 6: 4, 4: None}
+# The next-larger size a character die boosts to. A d12 is special-cased (it
+# stays and adds a d4), and no die ever boosts to the d20 fortune die.
+_LARGER_SIZE = {4: 6, 6: 8, 8: 10, 10: 12}
 
 
 def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
@@ -56,19 +59,24 @@ def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
     return answer, dicerolls[20]
 
 
-def calc_action(fortunedicerolls, characterdicerolls):
-    """Compute the action total, using the highest two rolls. Up to one fortune die may be used.
+def calc_action(fortunedicerolls, characterdicerolls, keep=2, modifier=0):
+    """Compute the action total from the highest ``keep`` rolls (max one fortune die).
 
-    Returns ``(answer, action_total)`` so callers can compare the numeric total
-    against an opposing counter total.
+    ``keep`` is 2 normally and 3 for Burn Out. ``modifier`` is a flat +/- applied
+    to the total (e.g. Unstable's -1). Returns ``(answer, action_total)`` so
+    callers can compare the numeric total against an opposing counter total.
     """
     try:
         action_dice = sorted(fortunedicerolls, reverse=True)[:1]
         action_dice += characterdicerolls
         action_dice.sort(reverse=True)
-        action_dice = action_dice[:2]
-        action_total = sum(action_dice)
-        answer = f"**Action Total: {str(action_total)}** {str(action_dice)}\n"
+        action_dice = action_dice[:keep]
+        base = sum(action_dice)
+        action_total = base + modifier
+        answer = f"**Action Total: {action_total}** {action_dice}"
+        if modifier:
+            answer += f" (= {base} {modifier:+d})"
+        answer += "\n"
     except Exception as exc:
         raise RollError(
             "Coding error flattening dice rolls and creating total."
@@ -76,8 +84,12 @@ def calc_action(fortunedicerolls, characterdicerolls):
     return answer, action_total
 
 
-def calc_impact(fortunedicerolls, characterdicerolls):
-    """Calculate the impact total"""
+def calc_impact(fortunedicerolls, characterdicerolls, modifier=0):
+    """Calculate the impact total.
+
+    ``modifier`` is a flat +/- applied on top of the rolled impact (e.g. Burst's
+    +2 Impact). The minimum-impact rule is computed before the modifier.
+    """
     try:
         # die results of 10 or higher on a d10 or 12 give two impact. It doesn't happen on a d20.
         fortune_high = fortunedicerolls[0] >= 4
@@ -88,15 +100,18 @@ def calc_impact(fortunedicerolls, characterdicerolls):
         # Minimum impact of 1, but only when the fortune die rolled 4+ (even a
         # countered action still accomplishes something). With no 4+ fortune die
         # and no qualifying character dice the impact is genuinely 0.
-        impact = max(raw, 1) if fortune_high else raw
+        computed = max(raw, 1) if fortune_high else raw
+        impact = computed + modifier
         answer = f"**Impact: {impact}** "
         answer += (
             f"(fortune={fortuneimpact} 2x={doublecharacterimpact} 1x={characterimpact})"
         )
+        if modifier:
+            answer += f" (= {computed} {modifier:+d})"
         # When that lone point comes only from the fortune die, it's the minimum
         # impact you keep even if the action is countered -- worth spelling out.
         if (
-            impact == 1
+            computed == 1
             and fortuneimpact == 1
             and not doublecharacterimpact
             and not characterimpact
@@ -216,3 +231,51 @@ def stress_adjust(dicecounts, overwhelmed, staggered):
         )
     except Exception as exc:
         raise RollError("Coding error applying stress.") from exc
+
+
+def _boost_one(dicecounts, size):
+    """Boost one die of ``size`` in the pool; return a note line (or None)."""
+    if size == 20:
+        return "(cannot boost the fortune die)"
+    if dicecounts.get(size, 0) < 1:
+        return f"(no d{size} to boost)"
+    if size == 12:
+        # A d12 stays and adds a d4 (it never boosts to a d20).
+        dicecounts[4] += 1
+        return "boosted d12 (added a d4)"
+    dicecounts[size] -= 1
+    dicecounts[_LARGER_SIZE[size]] += 1
+    return f"boosted d{size} → d{_LARGER_SIZE[size]}"
+
+
+def _reduce_one(dicecounts, size):
+    """Reduce one die of ``size`` in the pool; return a note line (or None)."""
+    if size == 20:
+        return "(cannot reduce the fortune die)"
+    if dicecounts.get(size, 0) < 1:
+        return f"(no d{size} to reduce)"
+    dicecounts[size] -= 1
+    smaller = _SMALLER_SIZE[size]
+    if smaller is None:
+        return f"reduced d{size} → removed"
+    dicecounts[smaller] += 1
+    return f"reduced d{size} → d{smaller}"
+
+
+def boost_reduce(dicecounts, boosts, reduces):
+    """Apply ``boost dN`` / ``reduce dN`` keywords to the pool before rolling.
+
+    Boosting steps a die up one size (boosting a d12 keeps it and adds a d4);
+    reducing steps it down (reducing a d4 removes it). The die must already be in
+    the pool. The fortune d20 is never boosted or reduced. Mutates and returns
+    ``(answer, dicecounts)``; the answer is empty when there is nothing to do.
+    """
+    try:
+        notes = [_boost_one(dicecounts, size) for size in boosts]
+        notes += [_reduce_one(dicecounts, size) for size in reduces]
+    except Exception as exc:
+        raise RollError("Coding error applying boost/reduce.") from exc
+
+    if not notes:
+        return "", dicecounts
+    return "**Boost/Reduce**\n" + "".join(f"-# {n}\n" for n in notes), dicecounts

--- a/test.py
+++ b/test.py
@@ -303,6 +303,70 @@ class TestRoller(unittest.TestCase):
         self.assertIn("No character dice", answer)
         self.assertEqual(out[20], 1)
 
+    def test_calc_action_burnout_keeps_three(self):
+        """Burn Out totals the highest three dice (still at most one fortune die)."""
+        answer, total = roller.calc_action([20, 19], [8, 6, 4], keep=3)
+        self.assertEqual(total, 34)  # 20 + 8 + 6, only one d20 allowed
+        self.assertIn("[20, 8, 6]", answer)
+
+    def test_calc_action_modifier(self):
+        """A flat modifier adjusts the action total and is shown."""
+        answer, total = roller.calc_action([20], [8, 6], modifier=-1)
+        self.assertEqual(total, 27)
+        self.assertIn("**Action Total: 27**", answer)
+        self.assertIn("(= 28 -1)", answer)
+
+    def test_calc_impact_modifier(self):
+        """A flat impact modifier (e.g. Burst +2) adds on top of rolled impact."""
+        answer = roller.calc_impact([20], [8, 6, 4, 2], modifier=2)
+        self.assertIn("**Impact: 6**", answer)  # rolled 4, +2
+        self.assertIn("(= 4 +2)", answer)
+
+    def test_boost_reduce(self):
+        """boost/reduce step a die one size; d12 boost adds a d4, d4 reduce removes."""
+        counts = {20: 1, 12: 0, 10: 0, 8: 1, 6: 0, 4: 0}
+        answer, out = roller.boost_reduce(counts, [8], [])
+        self.assertIn("boosted d8 → d10", answer)
+        self.assertEqual((out[8], out[10]), (0, 1))
+
+        counts = {20: 1, 12: 1, 10: 0, 8: 0, 6: 0, 4: 0}
+        answer, out = roller.boost_reduce(counts, [12], [])
+        self.assertIn("added a d4", answer)
+        self.assertEqual((out[12], out[4]), (1, 1))
+
+        counts = {20: 1, 12: 0, 10: 0, 8: 0, 6: 0, 4: 1}
+        answer, out = roller.boost_reduce(counts, [], [4])
+        self.assertIn("reduced d4 → removed", answer)
+        self.assertEqual(out[4], 0)
+
+    def test_boost_reduce_guards(self):
+        """The fortune die can't be boost/reduced, nor can an absent die."""
+        counts = {20: 1, 12: 0, 10: 0, 8: 0, 6: 0, 4: 0}
+        answer, _out = roller.boost_reduce(counts, [20], [8])
+        self.assertIn("cannot boost the fortune die", answer)
+        self.assertIn("no d8 to reduce", answer)
+        self.assertEqual(roller.boost_reduce(counts, [], [])[0], "")
+
+    def test_parse_modifiers(self):
+        """Roll-string keywords resolve to the right modifier fields."""
+        mods = roller._parse_modifiers("d20 2d10 -1")
+        self.assertEqual((mods.action_mod, mods.impact_mod), (-1, 0))
+
+        mods = roller._parse_modifiers("d20 +2 impact -1")
+        self.assertEqual((mods.action_mod, mods.impact_mod), (-1, 2))
+
+        mods = roller._parse_modifiers("d20 unstable")
+        self.assertEqual(mods.action_mod, -1)
+
+        mods = roller._parse_modifiers("d20 burst")
+        self.assertEqual(mods.impact_mod, 2)
+        self.assertTrue(mods.disadvantage)
+
+        mods = roller._parse_modifiers("d20 boost d8 reduce d4 burnout vs 21")
+        self.assertEqual((mods.boosts, mods.reduces), ([8], [4]))
+        self.assertTrue(mods.burnout)
+        self.assertEqual(mods.counter, 21)
+
 
 class TestBotCommands(unittest.TestCase):
     """Test that the bot exposes both prefix and slash (app) commands.

--- a/test.py
+++ b/test.py
@@ -270,46 +270,38 @@ class TestRoller(unittest.TestCase):
         self.assertIn("cannot inflict stress", fail)
 
     def test_stress_reduce(self):
-        """Overwhelmed OR Staggered reduces the highest character die one size."""
-        rolls = {20: [15], 12: [], 10: [9], 8: [3], 6: [], 4: []}
-        answer, out = roller.stress_adjust(rolls, True, False, random.Random(7))
-        self.assertIn("Reduced highest die: d10[9]", answer)
-        # The d10[9] is gone and a d8 was rerolled in; the d20 is untouched.
-        self.assertEqual(out[10], [])
-        self.assertEqual(len(out[8]), 2)
-        self.assertEqual(out[20], [15])
+        """Overwhelmed OR Staggered reduces the highest character die type pre-roll."""
+        counts = {20: 1, 12: 0, 10: 1, 8: 1, 6: 0, 4: 0}
+        answer, out = roller.stress_adjust(counts, True, False)
+        self.assertIn("Reduced highest die: d10 → d8", answer)
+        # The d10 became a d8 (so 2d8 now); the d20 is untouched.
+        self.assertEqual(out[10], 0)
+        self.assertEqual(out[8], 2)
+        self.assertEqual(out[20], 1)
 
     def test_stress_reduce_d4_removed(self):
         """Reducing a d4 drops it from the pool entirely."""
-        rolls = {20: [10], 12: [], 10: [], 8: [], 6: [], 4: [3]}
-        answer, out = roller.stress_adjust(rolls, False, True, random.Random(1))
-        self.assertIn("→ removed", answer)
-        self.assertEqual(out[4], [])
+        counts = {20: 1, 12: 0, 10: 0, 8: 0, 6: 0, 4: 1}
+        answer, out = roller.stress_adjust(counts, False, True)
+        self.assertIn("d4 → removed", answer)
+        self.assertEqual(out[4], 0)
 
     def test_stress_scratch(self):
-        """Overwhelmed AND Staggered scratches the highest character die."""
-        rolls = {20: [18], 12: [11], 10: [9], 8: [], 6: [], 4: []}
-        answer, out = roller.stress_adjust(rolls, True, True, random.Random(0))
-        self.assertIn("Scratched highest die: 11", answer)
-        self.assertEqual(out[12], [])
-        self.assertEqual(out[10], [9])
-
-    def test_stress_tiebreak_prefers_larger_die(self):
-        """On a tie the larger die size is the one adjusted."""
-        rolls = {20: [5], 12: [], 10: [6], 8: [], 6: [6], 4: []}
-        answer, out = roller.stress_adjust(rolls, True, True, random.Random(0))
-        self.assertIn("Scratched highest die: 6", answer)
-        self.assertEqual(out[10], [])
-        self.assertEqual(out[6], [6])
+        """Overwhelmed AND Staggered scratches the highest character die type."""
+        counts = {20: 1, 12: 1, 10: 1, 8: 0, 6: 0, 4: 0}
+        answer, out = roller.stress_adjust(counts, True, True)
+        self.assertIn("Scratched highest die: d12", answer)
+        self.assertEqual(out[12], 0)
+        self.assertEqual(out[10], 1)
 
     def test_stress_no_op_and_no_character_dice(self):
         """No stress flags is a no-op; stress with only a d20 changes nothing."""
-        rolls = {20: [15], 12: [], 10: [4], 8: [], 6: [], 4: []}
-        self.assertEqual(roller.stress_adjust(rolls, False, False)[0], "")
-        only_d20 = {20: [15], 12: [], 10: [], 8: [], 6: [], 4: []}
+        counts = {20: 1, 12: 0, 10: 1, 8: 0, 6: 0, 4: 0}
+        self.assertEqual(roller.stress_adjust(counts, False, False)[0], "")
+        only_d20 = {20: 1, 12: 0, 10: 0, 8: 0, 6: 0, 4: 0}
         answer, out = roller.stress_adjust(only_d20, True, False)
         self.assertIn("No character dice", answer)
-        self.assertEqual(out[20], [15])
+        self.assertEqual(out[20], 1)
 
 
 class TestBotCommands(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -214,14 +214,14 @@ class TestRoller(unittest.TestCase):
     def test_calc_action(self):
         """Ensure actions are tallied properly (only the highest fortune die counts)."""
         dataset = [
-            [[1, 20], [2, 4, 6, 8], "**Action Total: 28** [20, 8]\n"],
-            [[20, 1], [8, 6, 4, 2], "**Action Total: 28** [20, 8]\n"],
-            [[11, 13, 5], [8, 6, 4, 2], "**Action Total: 21** [13, 8]\n"],
-            [[6, 7, 8], [9, 10, 11, 12], "**Action Total: 23** [12, 11]\n"],
+            [[1, 20], [2, 4, 6, 8], "**Action Total: 28** [20, 8]\n", 28],
+            [[20, 1], [8, 6, 4, 2], "**Action Total: 28** [20, 8]\n", 28],
+            [[11, 13, 5], [8, 6, 4, 2], "**Action Total: 21** [13, 8]\n", 21],
+            [[6, 7, 8], [9, 10, 11, 12], "**Action Total: 23** [12, 11]\n", 23],
         ]
-        for fdice, cdice, answer in dataset:
+        for fdice, cdice, answer, total in dataset:
             with self.subTest(dice=[fdice, cdice]):
-                self.assertEqual(roller.calc_action(fdice, cdice), answer)
+                self.assertEqual(roller.calc_action(fdice, cdice), (answer, total))
 
     def test_calc_action_exc(self):
         """Give calc_action() some bad data."""
@@ -235,6 +235,81 @@ class TestRoller(unittest.TestCase):
         for fdice, cdice in dataset:
             with self.subTest(dice=[fdice, cdice]), self.assertRaises(roller.RollError):
                 roller.calc_action(fdice, cdice)
+
+    def test_crit_success(self):
+        """A 20 on the kept fortune die (index 0) is called out as a critical success."""
+        self.assertIn("**Critical Success**", roller.crit_success([20]))
+        self.assertIn("Impact by 2", roller.crit_success([20]))
+        # Only index 0 (the kept die) matters; an empty pool is no crit.
+        for fortune in ([19], [1], []):
+            with self.subTest(fortune=fortune):
+                self.assertEqual(roller.crit_success(fortune), "")
+
+    def test_calc_impact_minimum(self):
+        """Minimum impact of 1 applies only when the fortune die rolled 4+."""
+        # Fortune 5, no character die >= 4: the single point is the minimum, noted.
+        floored = roller.calc_impact([5], [2, 3])
+        self.assertIn("**Impact: 1**", floored)
+        self.assertIn("Minimum impact 1", floored)
+        # Fortune 2, no character die >= 4: stays 0, no minimum-impact note.
+        zero = roller.calc_impact([2], [2, 3])
+        self.assertIn("**Impact: 0**", zero)
+        self.assertNotIn("Minimum impact", zero)
+        # A normal result is unchanged and carries no note.
+        normal = roller.calc_impact([20], [8, 6, 4, 2])
+        self.assertIn("**Impact: 4**", normal)
+        self.assertNotIn("Minimum impact", normal)
+
+    def test_compare_counter(self):
+        """The optional counter total decides success (tie = success)."""
+        self.assertEqual(roller.compare_counter(20, None), "")
+        self.assertIn("**Success!**", roller.compare_counter(21, 21))
+        self.assertIn("**Success!**", roller.compare_counter(25, 21))
+        fail = roller.compare_counter(18, 21)
+        self.assertIn("**Failure**", fail)
+        self.assertIn("cannot inflict stress", fail)
+
+    def test_stress_reduce(self):
+        """Overwhelmed OR Staggered reduces the highest character die one size."""
+        rolls = {20: [15], 12: [], 10: [9], 8: [3], 6: [], 4: []}
+        answer, out = roller.stress_adjust(rolls, True, False, random.Random(7))
+        self.assertIn("Reduced highest die: d10[9]", answer)
+        # The d10[9] is gone and a d8 was rerolled in; the d20 is untouched.
+        self.assertEqual(out[10], [])
+        self.assertEqual(len(out[8]), 2)
+        self.assertEqual(out[20], [15])
+
+    def test_stress_reduce_d4_removed(self):
+        """Reducing a d4 drops it from the pool entirely."""
+        rolls = {20: [10], 12: [], 10: [], 8: [], 6: [], 4: [3]}
+        answer, out = roller.stress_adjust(rolls, False, True, random.Random(1))
+        self.assertIn("→ removed", answer)
+        self.assertEqual(out[4], [])
+
+    def test_stress_scratch(self):
+        """Overwhelmed AND Staggered scratches the highest character die."""
+        rolls = {20: [18], 12: [11], 10: [9], 8: [], 6: [], 4: []}
+        answer, out = roller.stress_adjust(rolls, True, True, random.Random(0))
+        self.assertIn("Scratched highest die: 11", answer)
+        self.assertEqual(out[12], [])
+        self.assertEqual(out[10], [9])
+
+    def test_stress_tiebreak_prefers_larger_die(self):
+        """On a tie the larger die size is the one adjusted."""
+        rolls = {20: [5], 12: [], 10: [6], 8: [], 6: [6], 4: []}
+        answer, out = roller.stress_adjust(rolls, True, True, random.Random(0))
+        self.assertIn("Scratched highest die: 6", answer)
+        self.assertEqual(out[10], [])
+        self.assertEqual(out[6], [6])
+
+    def test_stress_no_op_and_no_character_dice(self):
+        """No stress flags is a no-op; stress with only a d20 changes nothing."""
+        rolls = {20: [15], 12: [], 10: [4], 8: [], 6: [], 4: []}
+        self.assertEqual(roller.stress_adjust(rolls, False, False)[0], "")
+        only_d20 = {20: [15], 12: [], 10: [], 8: [], 6: [], 4: []}
+        answer, out = roller.stress_adjust(only_d20, True, False)
+        self.assertIn("No character dice", answer)
+        self.assertEqual(out[20], [15])
 
 
 class TestBotCommands(unittest.TestCase):


### PR DESCRIPTION
Adds MvK rules that `mvkroll` defines but didn't apply, verified against the **current corebook PDF** (`Mecha_Vs_Kaiju_202X_Corebook.pdf`, which supersedes the older 202X-V1.05 .docx). `RULES.md` is updated throughout with corebook quotes and per-rule "what the bot does" notes.

## Commits

1. **`feat:` critical success, minimum-impact note, stress, counter**
   - **Critical Success** — a 20 on the kept fortune die prints a callout (+2 Impact or 1 inspiration).
   - **Minimum Impact note** — calls out the guaranteed-1 case; impact floor is now correctly conditional on a 4+ fortune die (sub-4 with no 4+ dice is now 0, not 1).
   - **Counter** — `vs N` / `counter N` compares the Action Total (tie = success) with a no-stress note on failure.
   - **Stress** — `overwhelmed` / `staggered` keywords.

2. **`fix:` stress reduces the highest die *type* before rolling** — after re-checking the corebook (the .docx was self-contradictory on the Overwhelmed-AND-Staggered case). The corebook quick-ref says "Reduce/Scratch the highest die **type**," i.e. size, applied before rolling. Stress now adjusts dice *counts* pre-roll: one condition reduces the largest character die one size (d12→…→d4, a d4 is removed), both scratch it. The fortune d20 is never touched.

3. **`feat:` action/impact modifiers, boost/reduce, burnout, unstable/burst** — flat modifiers and ability keywords:
   - `+N`/`-N` adjust the action total; `impact +N` adjusts impact.
   - `boost dN`/`reduce dN` step a die up/down a size before rolling (boosting a d12 adds a d4; reducing a d4 removes it).
   - `burnout` totals the highest three dice instead of two.
   - `unstable` (−1 action total); `burst` (+2 impact, rolled with disadvantage).

## Implementation notes

- Rules math stays in `rollmvkhelpers.py`; `mvkroll` wires it in. Roll-string modifiers are parsed by `mvkroller._parse_modifiers` into a `Modifiers` namedtuple. Stress/boost/reduce adjust the pool *before* rolling; the raw-roll snapshot used for edit-reuse is still taken pre-mutation.
- `boost d8`/`reduce d4` contain a `dN` that `parse_dice` would otherwise roll, so those tokens are stripped before parsing the pool (`BOOST_REDUCE_RE`).
- MvK is deliberately a dice-not-modifiers system, so flat modifiers are rare and uncapped in normal play (the only `+N→die` table is a GM tool for porting 5E content). `burst`/`burnout` handle only the pure-dice parts — "double your Drive die" and extra trait dice are left to the player (the bot can't know which die that is); noted in help and RULES.md.

## Verification

- `python test.py` — 48 tests pass (new coverage for crit success, counter, minimum impact, stress reduce/scratch, action/impact modifiers, boost/reduce, burnout, and `_parse_modifiers`).
- `ruff check` + `ruff format --check` clean; `pylint` 10/10.
- Help text (`rollcog.py`), `README.md`, and `RULES.md` updated for all keywords. Live-tested on the dev bot in #dev.
