### PR TITLE
Tidy plainroll single-d20 callout formatting (from misc/formatting)

### DIFF
--- a/rollplainhelpers.py
+++ b/rollplainhelpers.py
@@ -31,13 +31,13 @@ def print_d20_special(dicerolls):
         for size, values in dicerolls.items():
             if len(values) == 1 and size == 20:
                 if values[0] == 1:
-                    answer += "\n1 is **Crit Fumble/Fail**"
+                    answer += " **(Crit Fumble/Fail)**"
                 elif values[0] == 20:
-                    answer += "\n20 is **Crit Success**"
+                    answer += " **(Crit Success)**"
                 elif values[0] % 2 == 0:
-                    answer += " (_Even_)"
+                    answer += " _(Even)_"
                 else:
-                    answer += " (_Odd_)"
+                    answer += " _(Odd)_"
 
                 if values[0] == 2:  # separate because also even
                     answer += "\n_Two-Weapon Hit?_"


### PR DESCRIPTION
Salvages the one useful change from the stale `misc/formatting` branch (commit 5bede34, "More tweaks for plain roll formatting of extra info"), reapplied onto current `main`. That branch predated the refactor that split `mvkroller.py`, so it can't be merged directly — the affected code now lives in `rollplainhelpers.py`.

## Change

`print_d20_special` (the single-d20 callouts in `plainroll`) — purely cosmetic:

- Crit fumble / crit success now render **inline** with parentheses instead of on their own line:
  - `\n1 is **Crit Fumble/Fail**` → ` **(Crit Fumble/Fail)**`
  - `\n20 is **Crit Success**` → ` **(Crit Success)**`
- Even/odd italics now wrap the parentheses too: ` (_Even_)` → ` _(Even)_` (likewise `_(Odd)_`).

I made the two crit lines lead with a space consistently — the original branch gave the fumble line no leading space but the success line one, which looked off next to each other and next to the even/odd callouts.

## Verification

- 48 tests pass; `ruff` + `pre-commit` clean; `pylint` 10/10. No tests pinned these strings.
- Rendered each single-d20 case to confirm (`1`, `20`, `2`→two-weapon, even, odd).
