### PR TITLE
Restructure roll output for a clearer visual hierarchy

### DIFF
--- a/escalationcog.py
+++ b/escalationcog.py
@@ -24,6 +24,7 @@ their attack rolls. This cog tracks one value per channel, in memory, and lets a
 channel's value lapse back to 0 after a period of inactivity.
 """
 
+import functools
 import time
 
 from discord import app_commands
@@ -148,7 +149,9 @@ class Escalation(commands.Cog):
         (text aliases '?esc', '?e'; also the '/esc' slash command). A channel's
         value resets to 0 after 12 hours of inactivity.
         """
-        await self._handle(ctx.channel.id, action, ctx.reply)
+        await self._handle(
+            ctx.channel.id, action, functools.partial(ctx.reply, mention_author=False)
+        )
 
     # Discord application commands have no alias mechanism, so '/esc' is its own
     # slash command reusing the same handler (there is intentionally no '/e').
@@ -170,7 +173,9 @@ class Escalation(commands.Cog):
         Usable as '?nextround'/'/nextround' (text aliases '?next', '?n'; also the
         '/n' slash command).
         """
-        await self._handle(ctx.channel.id, "next", ctx.reply)
+        await self._handle(
+            ctx.channel.id, "next", functools.partial(ctx.reply, mention_author=False)
+        )
 
     # As with '/esc', the '/n' slash form is its own command (no slash aliases).
     @app_commands.command(

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -134,6 +134,48 @@ def _parse_modifiers(dicestr):
     )
 
 
+def _mvk_result_lines(fortunedicerolls, characterdicerolls, mods):
+    """Build the crit header and the lines below the dice for an mvkroll.
+
+    Returns ``(crit_header, lines)`` where ``crit_header`` is the top-of-message
+    ``### …`` line (or ``""``) and ``lines`` are the breakdown subtext, the bold
+    ``Action Total -- Impact`` line, and any reminders/rewards/verdict that follow
+    it, in display order.
+    """
+    fumble_header, characterdicerolls = crit_fumble(
+        fortunedicerolls, characterdicerolls
+    )
+    cs_header, cs_choose = crit_success(fortunedicerolls)
+    possible = "" if fumble_header else possible_fumble(fortunedicerolls)
+
+    # Burn Out totals the highest three dice instead of two.
+    action_total, action_label, action_from = calc_action(
+        fortunedicerolls,
+        characterdicerolls,
+        keep=3 if mods.burnout else 2,
+        modifier=mods.action_mod,
+    )
+    impact_label, impact_from, min_note = calc_impact(
+        fortunedicerolls, characterdicerolls, modifier=mods.impact_mod
+    )
+
+    lines = [f"-# {action_from} — {impact_from}"]
+    if possible:
+        lines.append(possible)
+    lines.append(f"**{action_label} — {impact_label}**")
+    if min_note:
+        lines.append(f"-# {min_note}")
+    if cs_choose:
+        lines.append(cs_choose)
+    if fumble_header:
+        lines.append("**Gain 1 inspiration point**")
+    verdict = compare_counter(action_total, mods.counter)
+    if verdict:
+        lines.append(verdict)
+
+    return fumble_header or cs_header, lines
+
+
 def mvkroll(dicestr: str, prior_rolls=None):
     """Implementation of dice roller that applies MvK rules.
 
@@ -145,28 +187,34 @@ def mvkroll(dicestr: str, prior_rolls=None):
 
     logger.debug("Roll %s", {dicestr})
 
-    answer = ""
     mods = _parse_modifiers(dicestr)
 
     # Drop "boost dN"/"reduce dN" tokens so their target die isn't read as a die
     # to roll; the boost/reduce itself is applied from mods below.
     dicecounts = parse_dice(BOOST_REDUCE_RE.sub(" ", dicestr))
 
-    # advantage and disadvantage need _at least_ 2d20
-    # everything else only gets 1d20
+    # Pool-change notes (set-d20, boost/reduce, stress, advantage/disadvantage)
+    # are collected here and rendered together as one quiet subtext line.
+    pool_notes = []
+
+    # advantage and disadvantage need _at least_ 2d20; everything else gets 1d20.
     if mods.advantage or mods.disadvantage:
         if dicecounts[20] < 2:
             dicecounts[20] = 2
-            answer += "_Setting 2d20 for advantage/disadvantage_\n"
+            pool_notes.append("Set 2d20 for advantage/disadvantage")
     elif dicecounts[20] > 1 or dicecounts[20] == 0:
         dicecounts[20] = 1
-        answer += "_No advantage/disadvantage, setting 1d20_\n"
+        pool_notes.append("No advantage/disadvantage — using 1d20")
 
     # Pool changes happen before rolling: boost/reduce keywords, then stress
     # (which reduces/scratches the highest remaining character die *type*). Both
     # mutate dicecounts in place; we keep only their note text.
-    answer += boost_reduce(dicecounts, mods.boosts, mods.reduces)[0]
-    answer += stress_adjust(dicecounts, mods.overwhelmed, mods.staggered)[0]
+    for note in (
+        boost_reduce(dicecounts, mods.boosts, mods.reduces)[0],
+        stress_adjust(dicecounts, mods.overwhelmed, mods.staggered)[0],
+    ):
+        if note:
+            pool_notes.append(note)
 
     if prior_rolls is None:
         dicerolls = roll_dice(dicecounts)
@@ -182,13 +230,13 @@ def mvkroll(dicestr: str, prior_rolls=None):
     fortunedicerolls.sort(reverse=True)
     logger.debug("fortune rolls %s", fortunedicerolls)
 
-    adv_disadv_answer, fortunedicerolls = adv_disadv(
+    adv_note, fortunedicerolls = adv_disadv(
         mods.advantage, mods.disadvantage, dicecounts, dicerolls
     )
-    answer += adv_disadv_answer
+    if adv_note:
+        pool_notes.append(adv_note)
 
-    answer += print_dice(dicerolls)
-    answer += "\n"
+    dice_text = print_dice(dicerolls).rstrip()
 
     # dice d4-d12 are called "Character Dice"
     characterdicerolls = [
@@ -200,33 +248,21 @@ def mvkroll(dicestr: str, prior_rolls=None):
     if len(characterdicerolls) + len(fortunedicerolls) < 1:
         raise RollError("Not enough dice to roll")
 
-    possible_fumble_answer = possible_fumble(fortunedicerolls)
-
-    fumble_answer, characterdicerolls = crit_fumble(
-        fortunedicerolls, characterdicerolls
-    )
-    if fumble_answer:
-        answer += fumble_answer
-    elif possible_fumble_answer:
-        answer += possible_fumble_answer
-
-    answer += crit_success(fortunedicerolls)
-
-    # Burn Out totals the highest three dice instead of two.
-    action_answer, action_total = calc_action(
-        fortunedicerolls,
-        characterdicerolls,
-        keep=3 if mods.burnout else 2,
-        modifier=mods.action_mod,
-    )
-    answer += action_answer
-    answer += compare_counter(action_total, mods.counter)
-
-    answer += calc_impact(
-        fortunedicerolls, characterdicerolls, modifier=mods.impact_mod
+    crit_header, result_lines = _mvk_result_lines(
+        fortunedicerolls, characterdicerolls, mods
     )
 
-    return answer, rolls
+    # Assemble: a loud crit header on top, supporting detail as quiet -# subtext
+    # in the middle, and the headline numbers / rewards / verdict at the bottom.
+    lines = []
+    if crit_header:
+        lines.append(crit_header)
+    if pool_notes:
+        lines.append("-# " + " — ".join(pool_notes))
+    lines.append(f"-# {dice_text}")
+    lines.extend(result_lines)
+
+    return "\n".join(lines) + "\n", rolls
 
 
 def plainroll(dicestr: str, escalation: int = 0, prior_rolls=None):
@@ -242,8 +278,6 @@ def plainroll(dicestr: str, escalation: int = 0, prior_rolls=None):
 
     logger.debug("Roll %s", {dicestr})
 
-    answer = ""
-
     add_amount = parse_math(dicestr)
     logger.debug("add_amount %s", {add_amount})
 
@@ -253,9 +287,9 @@ def plainroll(dicestr: str, escalation: int = 0, prior_rolls=None):
     else:
         dicerolls = merge_rolls(prior_rolls, dicecounts)
 
-    answer += print_dice(dicerolls)
-    answer += print_d20_special(dicerolls)
-    answer += "\n"
+    header, callout = print_d20_special(dicerolls)
+    dice_text = print_dice(dicerolls).rstrip()
+    total = sum(sum(values) for values in dicerolls.values()) + add_amount
 
     # A single d20 (modifiers don't count) is the standard 13th Age attack roll,
     # so that's when the escalation die applies.
@@ -263,22 +297,26 @@ def plainroll(dicestr: str, escalation: int = 0, prior_rolls=None):
         count == 0 for size, count in dicecounts.items() if size != 20
     )
     show_escalation = single_d20 and escalation > 0
+
+    # A loud crit header on top; the dice and the modifier/escalation details as
+    # quiet -# subtext; the bold Total (and escalated total) at the bottom.
+    lines = []
+    if header:
+        lines.append(header)
+    lines.append(f"-# {dice_text}")
+    if callout:
+        lines.append(callout)
+
+    # Combine the flat modifier and the escalation die onto one subtext line.
+    if add_amount != 0 and show_escalation:
+        lines.append(f"-# Adjustment: {add_amount} + {NUMBER_EMOJI[escalation]}")
+    elif add_amount != 0:
+        lines.append(f"-# Adjustment: {add_amount}")
+    elif show_escalation:
+        lines.append(f"-# Esc: {NUMBER_EMOJI[escalation]}")
+
+    lines.append(f"**Total: {total}**")
     if show_escalation:
-        answer += f"-# Esc: {NUMBER_EMOJI[escalation]}\n"
+        lines.append(f"**w/Esc: {total + escalation}**")
 
-    total = 0
-
-    if add_amount != 0:
-        answer += f"Adjustment: {add_amount}\n"
-        total += add_amount
-
-    for size, values in dicerolls.items():
-        logger.debug("Dice size=%s values=%s", size, values)
-        total += sum(values)
-
-    answer += f"Total: **{total}**"
-
-    if show_escalation:
-        answer += f"\nw/Esc: **{total + escalation}**"
-
-    return answer, dicerolls
+    return "\n".join(lines) + "\n", dicerolls

--- a/rollcog.py
+++ b/rollcog.py
@@ -57,10 +57,15 @@ def echo_prefix(dicestr):
 
 
 def dice_line(text):
-    """Return the 'Dice: ...' line from a roll's rendered body, or None."""
+    """Return the 'Dice: ...' line from a roll's rendered body, or None.
+
+    The rollers render the dice as a quiet '-# Dice: ...' subtext line; the '-# '
+    prefix is stripped so the history entry strikes through just the dice.
+    """
     for line in text.split("\n"):
-        if line.startswith("Dice:"):
-            return line.rstrip()
+        stripped = line.removeprefix("-# ")
+        if stripped.startswith("Dice:"):
+            return stripped.rstrip()
     return None
 
 

--- a/rollcog.py
+++ b/rollcog.py
@@ -107,7 +107,8 @@ class Roll(commands.Cog):
             except discord.HTTPException:
                 reply = None  # our reply is gone; post a fresh one
         if reply is None:
-            reply = await ctx.reply(content)
+            # Reply (so it threads under the trigger) but don't ping the author.
+            reply = await ctx.reply(content, mention_author=False)
         self._remember(
             ctx.message.id, RollState(reply, state.rolls, state.text, state.history)
         )

--- a/rollmvkhelpers.py
+++ b/rollmvkhelpers.py
@@ -34,7 +34,12 @@ _LARGER_SIZE = {4: 6, 6: 8, 8: 10, 10: 12}
 
 
 def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
-    """Perform extra work when rolling with advantage or disadvantage"""
+    """Apply advantage/disadvantage, keeping one d20.
+
+    Returns ``(fragment, fortune)`` where ``fragment`` is a short subtext note
+    like ``"Advantage: kept 18 of [18, 5]"`` (empty when neither applies), built
+    from the original pair captured before the in-place sort.
+    """
     answer = ""
     fortunedicerolls = dicerolls[20]
 
@@ -42,17 +47,17 @@ def adv_disadv(advantage, disadvantage, dicecounts, dicerolls):
         if (advantage or disadvantage) and len(fortunedicerolls):
             logger.debug("Dicecounts %s", dicecounts)
             logger.debug("Dicerolls %s", dicerolls)
-            answer += "Original d20s: "
-            answer += f"{len(fortunedicerolls)}d20{str(fortunedicerolls)} -- "
+            original = list(fortunedicerolls)
             if advantage:
-                answer += "_Applying advantage_\n\n"
+                label = "Advantage"
                 dicerolls[20].sort(reverse=True)
                 logger.debug("Advantage rolls %s", dicerolls[20])
-            if disadvantage:
-                answer += "_Applying disadvantage_\n\n"
+            else:
+                label = "Disadvantage"
                 dicerolls[20].sort()
                 logger.debug("Disadvantage rolls %s", dicerolls[20])
             dicerolls[20] = [dicerolls[20][0]]
+            answer = f"{label}: kept {dicerolls[20][0]} of {original}"
     except Exception as exc:
         raise RollError("Coding error calculating advantage or disadvantage.") from exc
 
@@ -63,8 +68,10 @@ def calc_action(fortunedicerolls, characterdicerolls, keep=2, modifier=0):
     """Compute the action total from the highest ``keep`` rolls (max one fortune die).
 
     ``keep`` is 2 normally and 3 for Burn Out. ``modifier`` is a flat +/- applied
-    to the total (e.g. Unstable's -1). Returns ``(answer, action_total)`` so
-    callers can compare the numeric total against an opposing counter total.
+    to the total (e.g. Unstable's -1). Returns ``(action_total, label, from_frag)``
+    where ``label`` is e.g. ``"Action Total: 23"`` and ``from_frag`` the subtext
+    detail ``"action from: [15, 8]"`` (with ``(= base ±N)`` appended when there's
+    a modifier). The caller composes the final lines.
     """
     try:
         action_dice = sorted(fortunedicerolls, reverse=True)[:1]
@@ -73,22 +80,27 @@ def calc_action(fortunedicerolls, characterdicerolls, keep=2, modifier=0):
         action_dice = action_dice[:keep]
         base = sum(action_dice)
         action_total = base + modifier
-        answer = f"**Action Total: {action_total}** {action_dice}"
+        label = f"Action Total: {action_total}"
+        from_frag = f"action from: {action_dice}"
         if modifier:
-            answer += f" (= {base} {modifier:+d})"
-        answer += "\n"
+            from_frag += f" (= {base} {modifier:+d})"
     except Exception as exc:
         raise RollError(
             "Coding error flattening dice rolls and creating total."
         ) from exc
-    return answer, action_total
+    return action_total, label, from_frag
 
 
 def calc_impact(fortunedicerolls, characterdicerolls, modifier=0):
     """Calculate the impact total.
 
     ``modifier`` is a flat +/- applied on top of the rolled impact (e.g. Burst's
-    +2 Impact). The minimum-impact rule is computed before the modifier.
+    +2 Impact). The minimum-impact rule is computed before the modifier. Returns
+    ``(label, from_frag, min_note)`` where ``label`` is e.g. ``"Impact: 4"``,
+    ``from_frag`` the subtext detail ``"impact from: fortune 1 · doubles 0 ·
+    singles 3"`` (with ``(= computed ±N)`` appended when modified), and
+    ``min_note`` the minimum-impact sentence or ``""``. The caller composes the
+    final lines.
     """
     try:
         # die results of 10 or higher on a d10 or 12 give two impact. It doesn't happen on a d20.
@@ -102,62 +114,64 @@ def calc_impact(fortunedicerolls, characterdicerolls, modifier=0):
         # and no qualifying character dice the impact is genuinely 0.
         computed = max(raw, 1) if fortune_high else raw
         impact = computed + modifier
-        answer = f"**Impact: {impact}** "
-        answer += (
-            f"(fortune={fortuneimpact} 2x={doublecharacterimpact} 1x={characterimpact})"
+        label = f"Impact: {impact}"
+        from_frag = (
+            f"impact from: fortune {fortuneimpact} · "
+            f"doubles {doublecharacterimpact} · singles {characterimpact}"
         )
         if modifier:
-            answer += f" (= {computed} {modifier:+d})"
+            from_frag += f" (= {computed} {modifier:+d})"
         # When that lone point comes only from the fortune die, it's the minimum
         # impact you keep even if the action is countered -- worth spelling out.
+        min_note = ""
         if (
             computed == 1
             and fortuneimpact == 1
             and not doublecharacterimpact
             and not characterimpact
         ):
-            answer += "\n-# Minimum impact 1 from the fortune die (even if countered)."
+            min_note = "Minimum impact 1 from the fortune die (even if countered)."
     except Exception as exc:
         raise RollError("Coding error calculating Impact") from exc
-    return answer
+    return label, from_frag, min_note
 
 
 def crit_fumble(fortunedicerolls, characterdicerolls):
-    """Check if we had a critical fumble. If so, add output and discard lowest non-1 die"""
-    answer = ""
+    """Check for a critical fumble; if so, scratch the lowest non-1 die.
+
+    Returns ``(header, newdicerolls)``: ``header`` is the ``### 💥 Critical
+    Fumble`` line (with ``(scratched N)`` when a die was scratched), or ``""``
+    when there's no fumble. The bold inspiration line is emitted by the caller.
+    """
+    header = ""
     newdicerolls = characterdicerolls
     if fortunedicerolls[0] == 1:
-        answer += "**Critical Fumble**\n"
         characterdicerolls.sort()
         newdicerolls = []
-        scratched = False
+        scratched = None
         for i in characterdicerolls:
-            if scratched:
+            if scratched is not None:
                 newdicerolls.append(i)
             elif i == 1:
                 newdicerolls.append(i)
             else:
-                scratched = True
-                answer += f"*Scratched {i}*\n"
+                scratched = i
                 # no append because scratching this die
-
-        answer += "**Gain 1 inspiration point**\n"
-        answer += f"New character dice: {newdicerolls}\n"
-    return answer, newdicerolls
+        if scratched is None:
+            header = "### 💥 Critical Fumble"
+        else:
+            header = f"### 💥 Critical Fumble (scratched {scratched})"
+    return header, newdicerolls
 
 
 def possible_fumble(fortunedicerolls):
+    """A 1-3 on the d20 is a critical fumble *if* the action is countered.
+
+    Returns a plain reminder sentence (no markup) or ``""``.
     """
-    You also critically fumble if your action is successfully countered
-    and you roll a 1-3 on the d20
-    """
-    answer = ""
     if fortunedicerolls[0] <= 3:
-        answer += "**Possible Critical Fumble**\n"
-        answer += (
-            "If your action is successfully countered, gain 1 inspiration point.\n"
-        )
-    return answer
+        return "Possible critical fumble: if your action is countered, gain 1 inspiration point."
+    return ""
 
 
 def crit_success(fortunedicerolls):
@@ -166,13 +180,15 @@ def crit_success(fortunedicerolls):
     ``fortunedicerolls`` is sorted descending and (after advantage/disadvantage)
     holds the single kept die, so index 0 is the die used for the action total.
     A critical success and a critical fumble can't both happen on that one die.
+    Returns ``(header, choose)``: the ``### 🎯 Critical Success`` header and the
+    plain "Choose:" reminder, or ``("", "")`` when there's no critical success.
     """
     if fortunedicerolls and fortunedicerolls[0] == 20:
         return (
-            "**Critical Success**\n"
-            "Choose: increase your Impact by 2, or gain 1 inspiration point.\n"
+            "### 🎯 Critical Success",
+            "Choose: +2 Impact, or gain 1 inspiration point.",
         )
-    return ""
+    return "", ""
 
 
 def compare_counter(action_total, counter):
@@ -181,14 +197,15 @@ def compare_counter(action_total, counter):
     Per the rules, the action succeeds unless the counter total is *higher*, so
     a tie is a success. An unsuccessful action can't inflict stress, but the
     actor still gets their minimum impact, so we say so rather than zeroing it.
+    Returns the verdict line (no trailing newline) or ``""`` when no counter.
     """
     if counter is None:
         return ""
     if action_total >= counter:
-        return f"**Success!** (Action {action_total} vs Counter {counter})\n"
+        return f"✅ **Success** vs Counter {counter}"
     return (
-        f"**Failure** (Action {action_total} vs Counter {counter})\n"
-        "-# Countered: cannot inflict stress; minimum impact still applies.\n"
+        f"❌ **Failure** vs Counter {counter} "
+        "_(no stress; minimum impact still applies)_"
     )
 
 
@@ -209,15 +226,12 @@ def stress_adjust(dicecounts, overwhelmed, staggered):
     try:
         size = next((s for s in (12, 10, 8, 6, 4) if dicecounts.get(s, 0) > 0), None)
         if size is None:
-            return "**Stress**\n-# No character dice to reduce.\n", dicecounts
+            return "Stress: no character dice to reduce", dicecounts
 
         dicecounts[size] -= 1
 
         if overwhelmed and staggered:
-            return (
-                f"**Stress: Overwhelmed & Staggered**\n*Scratched highest die: d{size}*\n",
-                dicecounts,
-            )
+            return f"Stress: scratched highest die d{size}", dicecounts
 
         smaller = _SMALLER_SIZE[size]
         if smaller is None:
@@ -225,10 +239,7 @@ def stress_adjust(dicecounts, overwhelmed, staggered):
         else:
             dicecounts[smaller] += 1
             detail = f"d{size} → d{smaller}"
-        return (
-            f"**Stress: Overwhelmed/Staggered**\n*Reduced highest die: {detail}*\n",
-            dicecounts,
-        )
+        return f"Stress: reduced highest die {detail}", dicecounts
     except Exception as exc:
         raise RollError("Coding error applying stress.") from exc
 
@@ -278,4 +289,4 @@ def boost_reduce(dicecounts, boosts, reduces):
 
     if not notes:
         return "", dicecounts
-    return "**Boost/Reduce**\n" + "".join(f"-# {n}\n" for n in notes), dicecounts
+    return " — ".join(notes), dicecounts

--- a/rollplainhelpers.py
+++ b/rollplainhelpers.py
@@ -25,27 +25,37 @@ from rollcommon import RollError
 
 
 def print_d20_special(dicerolls):
-    """Checks for special d20 rules and adds stuff for any special stuff"""
-    answer = ""
+    """Check a single d20 for special results.
+
+    Returns ``(header, callout)``: ``header`` is a top-of-message ``### 🎯/💥``
+    crit line for a natural 20/1 (empty otherwise); ``callout`` is the even/odd
+    (and Two-Weapon on a 2) note shown on its own line after the dice (empty for
+    a crit, or when this isn't a lone d20). Both empty when there's no single d20.
+    """
+    header = ""
+    callout = ""
     try:
-        for size, values in dicerolls.items():
-            if len(values) == 1 and size == 20:
-                if values[0] == 1:
-                    answer += " **(Crit Fumble/Fail)**"
-                elif values[0] == 20:
-                    answer += " **(Crit Success)**"
-                elif values[0] % 2 == 0:
-                    answer += " _(Even)_"
-                else:
-                    answer += " _(Odd)_"
+        values = dicerolls.get(20, [])
+        only_d20 = len(values) == 1 and all(
+            len(rolls) == 0 for size, rolls in dicerolls.items() if size != 20
+        )
+        if only_d20:
+            value = values[0]
+            if value == 20:
+                header = "### 🎯 Critical Success"
+            elif value == 1:
+                header = "### 💥 Critical Fumble"
+            elif value % 2 == 0:
+                callout = "(Even)"
+            else:
+                callout = "(Odd)"
 
-                if values[0] == 2:  # separate because also even
-                    answer += "\n_Two-Weapon Hit?_"
-
+            if value == 2:  # separate because also even
+                callout += " — Two-Weapon Hit?"
     except Exception as exc:
         raise RollError("Coding error displaying Dice") from exc
 
-    return answer
+    return header, callout
 
 
 def parse_math(dicestr: str):

--- a/test.py
+++ b/test.py
@@ -89,9 +89,10 @@ class TestRoller(unittest.TestCase):
     def test_plainroll_escalation_shown(self):
         """A single d20 with escalation > 0 shows the Esc line and escalated total."""
         out, _rolls = roller.plainroll("d20 +7", escalation=3)
-        self.assertIn("-# Esc: :three:", out)
-        total = int(re.search(r"Total: \*\*(-?\d+)\*\*", out).group(1))
-        w_esc = int(re.search(r"w/Esc: \*\*(-?\d+)\*\*", out).group(1))
+        # Adjustment and escalation now share one subtext line.
+        self.assertIn(":three:", out)
+        total = int(re.search(r"\*\*Total: (-?\d+)\*\*", out).group(1))
+        w_esc = int(re.search(r"\*\*w/Esc: (-?\d+)\*\*", out).group(1))
         self.assertEqual(w_esc, total + 3)
 
     def test_plainroll_escalation_hidden(self):
@@ -214,14 +215,22 @@ class TestRoller(unittest.TestCase):
     def test_calc_action(self):
         """Ensure actions are tallied properly (only the highest fortune die counts)."""
         dataset = [
-            [[1, 20], [2, 4, 6, 8], "**Action Total: 28** [20, 8]\n", 28],
-            [[20, 1], [8, 6, 4, 2], "**Action Total: 28** [20, 8]\n", 28],
-            [[11, 13, 5], [8, 6, 4, 2], "**Action Total: 21** [13, 8]\n", 21],
-            [[6, 7, 8], [9, 10, 11, 12], "**Action Total: 23** [12, 11]\n", 23],
+            [[1, 20], [2, 4, 6, 8], 28, "Action Total: 28", "action from: [20, 8]"],
+            [[20, 1], [8, 6, 4, 2], 28, "Action Total: 28", "action from: [20, 8]"],
+            [[11, 13, 5], [8, 6, 4, 2], 21, "Action Total: 21", "action from: [13, 8]"],
+            [
+                [6, 7, 8],
+                [9, 10, 11, 12],
+                23,
+                "Action Total: 23",
+                "action from: [12, 11]",
+            ],
         ]
-        for fdice, cdice, answer, total in dataset:
+        for fdice, cdice, total, label, from_frag in dataset:
             with self.subTest(dice=[fdice, cdice]):
-                self.assertEqual(roller.calc_action(fdice, cdice), (answer, total))
+                self.assertEqual(
+                    roller.calc_action(fdice, cdice), (total, label, from_frag)
+                )
 
     def test_calc_action_exc(self):
         """Give calc_action() some bad data."""
@@ -238,42 +247,44 @@ class TestRoller(unittest.TestCase):
 
     def test_crit_success(self):
         """A 20 on the kept fortune die (index 0) is called out as a critical success."""
-        self.assertIn("**Critical Success**", roller.crit_success([20]))
-        self.assertIn("Impact by 2", roller.crit_success([20]))
+        header, choose = roller.crit_success([20])
+        self.assertIn("Critical Success", header)
+        self.assertIn("Impact", choose)
+        self.assertIn("inspiration", choose)
         # Only index 0 (the kept die) matters; an empty pool is no crit.
         for fortune in ([19], [1], []):
             with self.subTest(fortune=fortune):
-                self.assertEqual(roller.crit_success(fortune), "")
+                self.assertEqual(roller.crit_success(fortune), ("", ""))
 
     def test_calc_impact_minimum(self):
         """Minimum impact of 1 applies only when the fortune die rolled 4+."""
         # Fortune 5, no character die >= 4: the single point is the minimum, noted.
-        floored = roller.calc_impact([5], [2, 3])
-        self.assertIn("**Impact: 1**", floored)
-        self.assertIn("Minimum impact 1", floored)
+        label, _frag, min_note = roller.calc_impact([5], [2, 3])
+        self.assertEqual(label, "Impact: 1")
+        self.assertIn("Minimum impact 1", min_note)
         # Fortune 2, no character die >= 4: stays 0, no minimum-impact note.
-        zero = roller.calc_impact([2], [2, 3])
-        self.assertIn("**Impact: 0**", zero)
-        self.assertNotIn("Minimum impact", zero)
+        label, _frag, min_note = roller.calc_impact([2], [2, 3])
+        self.assertEqual(label, "Impact: 0")
+        self.assertEqual(min_note, "")
         # A normal result is unchanged and carries no note.
-        normal = roller.calc_impact([20], [8, 6, 4, 2])
-        self.assertIn("**Impact: 4**", normal)
-        self.assertNotIn("Minimum impact", normal)
+        label, _frag, min_note = roller.calc_impact([20], [8, 6, 4, 2])
+        self.assertEqual(label, "Impact: 4")
+        self.assertEqual(min_note, "")
 
     def test_compare_counter(self):
         """The optional counter total decides success (tie = success)."""
         self.assertEqual(roller.compare_counter(20, None), "")
-        self.assertIn("**Success!**", roller.compare_counter(21, 21))
-        self.assertIn("**Success!**", roller.compare_counter(25, 21))
+        self.assertIn("Success", roller.compare_counter(21, 21))
+        self.assertIn("Success", roller.compare_counter(25, 21))
         fail = roller.compare_counter(18, 21)
-        self.assertIn("**Failure**", fail)
-        self.assertIn("cannot inflict stress", fail)
+        self.assertIn("Failure", fail)
+        self.assertIn("no stress", fail)
 
     def test_stress_reduce(self):
         """Overwhelmed OR Staggered reduces the highest character die type pre-roll."""
         counts = {20: 1, 12: 0, 10: 1, 8: 1, 6: 0, 4: 0}
         answer, out = roller.stress_adjust(counts, True, False)
-        self.assertIn("Reduced highest die: d10 → d8", answer)
+        self.assertIn("reduced highest die d10 → d8", answer)
         # The d10 became a d8 (so 2d8 now); the d20 is untouched.
         self.assertEqual(out[10], 0)
         self.assertEqual(out[8], 2)
@@ -290,7 +301,7 @@ class TestRoller(unittest.TestCase):
         """Overwhelmed AND Staggered scratches the highest character die type."""
         counts = {20: 1, 12: 1, 10: 1, 8: 0, 6: 0, 4: 0}
         answer, out = roller.stress_adjust(counts, True, True)
-        self.assertIn("Scratched highest die: d12", answer)
+        self.assertIn("scratched highest die d12", answer)
         self.assertEqual(out[12], 0)
         self.assertEqual(out[10], 1)
 
@@ -300,27 +311,27 @@ class TestRoller(unittest.TestCase):
         self.assertEqual(roller.stress_adjust(counts, False, False)[0], "")
         only_d20 = {20: 1, 12: 0, 10: 0, 8: 0, 6: 0, 4: 0}
         answer, out = roller.stress_adjust(only_d20, True, False)
-        self.assertIn("No character dice", answer)
+        self.assertIn("no character dice", answer)
         self.assertEqual(out[20], 1)
 
     def test_calc_action_burnout_keeps_three(self):
         """Burn Out totals the highest three dice (still at most one fortune die)."""
-        answer, total = roller.calc_action([20, 19], [8, 6, 4], keep=3)
+        total, _label, from_frag = roller.calc_action([20, 19], [8, 6, 4], keep=3)
         self.assertEqual(total, 34)  # 20 + 8 + 6, only one d20 allowed
-        self.assertIn("[20, 8, 6]", answer)
+        self.assertIn("[20, 8, 6]", from_frag)
 
     def test_calc_action_modifier(self):
         """A flat modifier adjusts the action total and is shown."""
-        answer, total = roller.calc_action([20], [8, 6], modifier=-1)
+        total, label, from_frag = roller.calc_action([20], [8, 6], modifier=-1)
         self.assertEqual(total, 27)
-        self.assertIn("**Action Total: 27**", answer)
-        self.assertIn("(= 28 -1)", answer)
+        self.assertEqual(label, "Action Total: 27")
+        self.assertIn("(= 28 -1)", from_frag)
 
     def test_calc_impact_modifier(self):
         """A flat impact modifier (e.g. Burst +2) adds on top of rolled impact."""
-        answer = roller.calc_impact([20], [8, 6, 4, 2], modifier=2)
-        self.assertIn("**Impact: 6**", answer)  # rolled 4, +2
-        self.assertIn("(= 4 +2)", answer)
+        label, from_frag, _min = roller.calc_impact([20], [8, 6, 4, 2], modifier=2)
+        self.assertEqual(label, "Impact: 6")  # rolled 4, +2
+        self.assertIn("(= 4 +2)", from_frag)
 
     def test_boost_reduce(self):
         """boost/reduce step a die one size; d12 boost adds a d4, d4 reduce removes."""
@@ -366,6 +377,37 @@ class TestRoller(unittest.TestCase):
         self.assertEqual((mods.boosts, mods.reduces), ([8], [4]))
         self.assertTrue(mods.burnout)
         self.assertEqual(mods.counter, 21)
+
+    def test_mvkroll_assembly(self):
+        """A basic roll renders as Dice + breakdown subtext then the bold result.
+
+        Passing prior_rolls that already match the pool makes the roll
+        deterministic (merge_rolls re-rolls nothing), so the exact lines are
+        checkable.
+        """
+        text, _rolls = roller.mvkroll(
+            "d20 2d10 d8 2d6",
+            prior_rolls={20: [15], 10: [8, 3], 8: [5], 6: [6, 2]},
+        )
+        lines = text.strip().split("\n")
+        self.assertEqual(lines[0], "-# Dice: 1d20[15] 2d10[8, 3] 1d8[5] 2d6[6, 2]")
+        self.assertEqual(
+            lines[1],
+            "-# action from: [15, 8] — impact from: fortune 1 · doubles 0 · singles 3",
+        )
+        self.assertEqual(lines[2], "**Action Total: 23 — Impact: 4**")
+
+    def test_mvkroll_crit_and_counter_order(self):
+        """A crit leads with a ### header; the success verdict is the last line."""
+        text, _rolls = roller.mvkroll(
+            "d20 2d10 d8 vs 21",
+            prior_rolls={20: [20], 10: [9, 2], 8: [7]},
+        )
+        lines = text.strip().split("\n")
+        self.assertEqual(lines[0], "### 🎯 Critical Success")
+        self.assertTrue(lines[-1].startswith("✅"))
+        self.assertIn("Success", lines[-1])
+        self.assertTrue(any(line.startswith("Choose:") for line in lines))
 
 
 class TestBotCommands(unittest.TestCase):


### PR DESCRIPTION
Reworks the rendered output of `mvkroll`/`plainroll` for consistency, less redundancy, and better scannability — and stops prefix-command replies from pinging the author.

## Formatting
- One consistent vocabulary: `###` crit headers (🎯/💥) at the top, **bold** for the headline `Action Total — Impact` line / verdict / tracked rewards, plain text for conditional reminders, and quiet `-#` subtext for the dice line, breakdowns, and pool bookkeeping.
- Hierarchy puts the numbers players/DM care about at the **edges** (top header, bottom result/verdict) and demotes bookkeeping to the middle.
- Removes the duplicated d20 line (old `Original d20s:` + blank line) and collapses pool changes (stress, boost/reduce, advantage, set-d20) onto a single subtext line.
- `plainroll`: single-d20 crits now use the same `###` headers; `Dice:` is subtext; Even/Odd/Two-Weapon move to their own (plain) line after the dice; whole `**Total: N**`/`**w/Esc: N**` lines are bold; adjustment + escalation condense to one line. Even/odd/crit callouts now only fire for a lone d20.
- All `--` separators are real em dashes.

Internally, the rules helpers now return fragments/data and `mvkroll` owns final line assembly (`_mvk_result_lines`); `rollcog.dice_line` strips the new `-# ` prefix so edit-history striking still works.

## Replies
- `?`-command replies (rolls, escalation, nextround) still thread under the trigger message but no longer ping/notify the author (`mention_author=False`). Slash commands were already silent.

## Tests
- All 50 unit tests pass (updated for the new return shapes/strings; added assembly + crit/counter ordering tests). pylint 10/10, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)