### PR TITLE
Accept / as a text command prefix

### DIFF
--- a/mvkdicebot.py
+++ b/mvkdicebot.py
@@ -48,7 +48,7 @@ intents = discord.Intents.default()
 intents.message_content = True  # pylint: disable=assigning-non-slot
 
 bot = commands.AutoShardedBot(
-    command_prefix=commands.when_mentioned_or("?"),
+    command_prefix=commands.when_mentioned_or("?", "/"),
     description=DESCRIPTION,
     intents=intents,
 )


### PR DESCRIPTION
Pass 1 of 2 on configurable prefixes.

Adds `/` as a text command prefix alongside the existing `?` and @-mention, without touching the native slash commands.

`mvkdicebot.py`: `command_prefix=commands.when_mentioned_or("?", "/")`.

## Why it's safe
- The prefix is constructed in exactly one place; nothing else reads or depends on it.
- No tests assert on the prefix (they check command/alias/app-command *registration*).
- Slash-command interactions dispatch on a separate path from text messages (`hybrid_command` branches on `ctx.interaction is None`), so a slash command and a text message starting with `/` can't double-fire. Unknown `/...` text just raises `CommandNotFound` and is ignored, exactly like `?...` today.

## Notes
- For commands that also exist as slash commands (`r`, `p`, …), the Discord client surfaces the slash UI when you type `/`, so the slash version is what users hit there — same result. The `/` text prefix is cleanly observable via aliases without a slash equivalent (e.g. `/roll 1d20`).
- Help text / README still say `?`; those are intentionally deferred to Pass 2, which makes the prefix set per-guild configurable (sqlite + `/setprefixes`) and reworks the wording in one coherent pass.

Tested live on the dev bot; all 50 unit tests pass, pylint 10/10, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)