### PR TITLE
Per-guild configurable command prefixes (/setprefixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 ## project-specific:
 mvkdicebot.ini
+mvkdicebot.sqlite3
+mvkdicebot.sqlite3-journal
 
 ## Rulebook PDFs (large, copyrighted) kept locally for reference:
 *.pdf

--- a/README.md
+++ b/README.md
@@ -10,10 +10,18 @@ Dice bot for MvK ruleset...
 
 ## Commands
 
-The bot understands these commands. Each can be invoked three ways: with the
+The bot understands these commands. Each can be invoked three ways: with a
 text prefix (`?mvkroll 1d20 2d10`, plus aliases like `?r`, `?roll`, `?p`), by
 mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
 (`/mvkroll dice:1d20 2d10`).
+
+Each server has its own text prefixes. Servers the bot was already in keep the
+classic `?` and `/` (so `?r 1d20` and `/r 1d20` both work); a server the bot
+joins fresh starts with no text prefixes (only @-mention and slash commands). A
+member with the **Manage Server** permission changes them with `/setprefixes` —
+e.g. `/setprefixes ?/!`, or `/setprefixes none` for only @-mention and slash
+commands; run it with no argument to see the current set. The bot always responds
+to @-mentions and to its slash commands regardless.
 
 - `mvkroll` — rolls a dice pool and applies the MvK rules math (action total,
   impact, advantage/disadvantage, fumbles, and critical success). It also
@@ -42,6 +50,11 @@ mentioning the bot (`@MvkDiceBot roll 1d20 2d10`), or as a slash command
 - `help` — auto-generated command list and usage. Available as `?help`,
   `@MvkDiceBot help`, or `/help` (optionally pass a command name, e.g.
   `/help command:mvkroll`).
+- `setprefixes` — shows or sets this server's text command prefixes (pass `none`
+  to use only @-mention and slash commands). Available as `?setprefixes`,
+  `@MvkDiceBot setprefixes`, or `/setprefixes`, restricted to the server owner,
+  administrators, or members with Manage Server (and only shown in `?help` to
+  them).
 
 Editing a text/mention roll message updates the bot's existing reply and
 re-rolls only the dice you added (existing dice are kept). Each prior `Dice:`

--- a/helpcog.py
+++ b/helpcog.py
@@ -18,9 +18,14 @@
 # https://github.com/freiheit/MvKDiceBot
 """Help command for MvKDiceBot, usable as both ?help and /help."""
 
+import itertools
+
 import discord
 from discord import app_commands
 from discord.ext import commands
+
+# Help sections are listed alphabetically by default; this one is pinned last.
+LAST_CATEGORY = "Configuration"
 
 
 class _HelpDestination:  # pylint: disable=too-few-public-methods
@@ -51,6 +56,43 @@ class HybridHelpCommand(commands.DefaultHelpCommand):
 
     def get_destination(self):
         return _HelpDestination(self.context)
+
+    async def send_bot_help(self, mapping, /):  # pylint: disable=unused-argument
+        """List sections like the default, but pin the Configuration section last.
+
+        ``DefaultHelpCommand`` orders sections alphabetically; we keep that for
+        everything except the ``LAST_CATEGORY`` section, which sorts to the end.
+        """
+        bot = self.context.bot
+        if bot.description:
+            self.paginator.add_line(bot.description, empty=True)
+
+        no_category = f"\u200b{self.no_category}:"
+
+        def get_category(command, *, no_category=no_category):
+            cog = command.cog
+            return cog.qualified_name + ":" if cog is not None else no_category
+
+        filtered = await self.filter_commands(bot.commands, sort=False)
+        max_size = self.get_max_size(filtered)
+
+        # Alphabetical, except LAST_CATEGORY is forced to the bottom.
+        filtered.sort(
+            key=lambda c: (get_category(c) == f"{LAST_CATEGORY}:", get_category(c))
+        )
+
+        for category, cmds in itertools.groupby(filtered, key=get_category):
+            cmds = (
+                sorted(cmds, key=lambda c: c.name) if self.sort_commands else list(cmds)
+            )
+            self.add_indented_commands(cmds, heading=category, max_size=max_size)
+
+        note = self.get_ending_note()
+        if note:
+            self.paginator.add_line()
+            self.paginator.add_line(note)
+
+        await self.send_pages()
 
 
 class Help(commands.Cog):

--- a/mvkconfig.py
+++ b/mvkconfig.py
@@ -74,6 +74,15 @@ def get_config():
     return config
 
 
+def get_database_path(config):
+    """Return the sqlite database path (config ``MAIN.database`` or a default).
+
+    The default lives alongside the code so a plain checkout works out of the box;
+    it is gitignored. Used for the per-guild prefix store (prefixstore.py).
+    """
+    return config["MAIN"].get("database", os.path.join(BASE_DIR, "mvkdicebot.sqlite3"))
+
+
 def get_primary_guild_ids(config):
     """Return the optional `primary_guilds` config value as a list of guild IDs.
 

--- a/mvkdicebot.example.ini
+++ b/mvkdicebot.example.ini
@@ -13,6 +13,10 @@ authtoken = abc1234
 # ("guild" is the Discord API term for a server.)
 primary_guilds = 986425163744673874, 910663839220105227
 
+# Optional: path to the sqlite database used to store per-guild command prefixes.
+# Defaults to "mvkdicebot.sqlite3" next to the code (gitignored).
+# database = mvkdicebot.sqlite3
+
 # debug levels:
 # 0 -> startup and errors only
 # 1 -> small amounts of info

--- a/mvkdicebot.py
+++ b/mvkdicebot.py
@@ -24,6 +24,7 @@ import discord
 from discord.ext import commands
 
 import mvkconfig
+import prefixstore
 
 __version__ = "1.0.0"
 DESCRIPTION = """A dice rolling bot for MvK
@@ -34,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 # Cogs (loaded as discord.py extensions in setup_hook). Each module provides the
 # commands and an `async def setup(bot)` entry point.
-EXTENSIONS = ("rollcog", "helpcog", "escalationcog")
+EXTENSIONS = ("rollcog", "helpcog", "escalationcog", "prefixcog")
 
 # Guild IDs to register slash commands in directly, for instant updates instead
 # of waiting on global propagation. Populated from the config in main(); an empty
@@ -47,8 +48,23 @@ intents = discord.Intents.default()
 # intents.messages = True
 intents.message_content = True  # pylint: disable=assigning-non-slot
 
+
+async def get_prefix(the_bot, message):
+    """Resolve the command prefixes for a message.
+
+    Always includes the two @-mention forms, plus the guild's configured text
+    prefixes from ``the_bot.prefix_store`` (the defaults when a guild hasn't set
+    any, or in DMs). Slash commands are separate application commands and work
+    regardless of this.
+    """
+    store = getattr(the_bot, "prefix_store", None)
+    guild_id = message.guild.id if message.guild else None
+    prefixes = store.get(guild_id) if store else list(prefixstore.DEFAULT_PREFIXES)
+    return commands.when_mentioned_or(*prefixes)(the_bot, message)
+
+
 bot = commands.AutoShardedBot(
-    command_prefix=commands.when_mentioned_or("?", "/"),
+    command_prefix=get_prefix,
     description=DESCRIPTION,
     intents=intents,
 )
@@ -93,9 +109,21 @@ async def setup_hook():
 
 @bot.event
 async def on_ready():
-    """Log when we start up"""
+    """Log when we start up, and seed default prefixes on first run.
+
+    The first time the bot runs with a brand-new database, seed the classic
+    ``?``/``/`` prefixes onto the guilds it's already in so they keep working;
+    guilds joined afterwards start mention/slash only. Guarded so it runs once
+    even though on_ready can fire again on reconnects.
+    """
     # pylint: disable=logging-fstring-interpolation
     logger.warning(f"Logged in as {bot.user} (ID {bot.user.id})")
+
+    store = getattr(bot, "prefix_store", None)
+    if store is not None and store.created:
+        seeded = store.backfill(guild.id for guild in bot.guilds)
+        store.created = False
+        logger.warning("Seeded default prefixes for %d existing guild(s)", seeded)
 
 
 @bot.tree.error
@@ -108,6 +136,17 @@ async def on_app_command_error(interaction, error):
     "This interaction failed". If the command already replied (e.g. a RollError
     message), is_done() is true and we only log.
     """
+    # A failed permission/guild check isn't a bug -- tell the user plainly.
+    if isinstance(error, discord.app_commands.CheckFailure):
+        if not interaction.response.is_done():
+            try:
+                await interaction.response.send_message(
+                    "You don't have permission to use that command.", ephemeral=True
+                )
+            except discord.HTTPException:
+                logger.exception("Failed to send permission error message")
+        return
+
     logger.error("Error in application command %s", interaction.command, exc_info=error)
     if not interaction.response.is_done():
         try:
@@ -122,6 +161,12 @@ def main():
     """Load configuration and run the bot."""
     config = mvkconfig.get_config()
     primary_guild_ids.extend(mvkconfig.get_primary_guild_ids(config))
+
+    # Load per-guild prefixes once at startup; changes are written through to the
+    # database as they happen (see prefixstore / prefixcog).
+    bot.prefix_store = prefixstore.PrefixStore(
+        mvkconfig.get_database_path(config)
+    ).load()
 
     bot.run(
         token=config["MAIN"].get("authtoken"),

--- a/prefixcog.py
+++ b/prefixcog.py
@@ -1,0 +1,161 @@
+#!.venv/bin/python3
+# MvKDiceBot: Discord bot for rolling dice for Mecha Vs Kaiju
+# Copyright (C) 2023  Eric Eisenhart
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Per-guild command-prefix configuration for MvKDiceBot.
+
+Provides the ``setprefixes`` command (restricted to the guild owner,
+administrators, or members with Manage Server) for showing or changing a server's
+text command prefixes. It's a hybrid command, so it works as a text/prefix
+command, via @-mention, and as the ``/setprefixes`` slash command. The values
+live in ``bot.prefix_store`` (see prefixstore.py), which the bot's prefix resolver
+reads for every message.
+"""
+
+import logging
+
+from discord import app_commands
+from discord.ext import commands
+
+import prefixstore
+
+logger = logging.getLogger(__name__)
+
+SETPREFIXES_HELP = (
+    "Characters to use as prefixes, e.g. '?/!' (replaces the current set); "
+    "'none' for only @-mention and slash commands; blank to show the current set."
+)
+
+# Arguments that mean "no text prefixes" (only @-mention and slash commands).
+CLEAR_WORDS = ("none", "clear", "off")
+
+
+def may_manage_prefixes(ctx):
+    """True if ``ctx.author`` may change prefixes: owner, admin, or Manage Server.
+
+    Explicit (rather than only ``manage_guild``) so the guild owner always
+    qualifies even with no role granting Manage Server, which also makes ``?help``
+    list the command for them. Raises so command checks report the right reason.
+    """
+    if ctx.guild is None:
+        raise commands.NoPrivateMessage()
+    perms = ctx.author.guild_permissions
+    if ctx.author.id == ctx.guild.owner_id or perms.administrator or perms.manage_guild:
+        return True
+    raise commands.MissingPermissions(["manage_guild"])
+
+
+def can_manage_prefixes():
+    """The command check wrapping :func:`may_manage_prefixes`."""
+    return commands.check(may_manage_prefixes)
+
+
+def describe(prefixes):
+    """Phrase a guild's prefix list for a reply."""
+    if not prefixes:
+        return "none (only @-mention and slash commands)"
+    return (
+        f"{prefixstore.format_prefixes(prefixes)} (plus @-mention and slash commands)"
+    )
+
+
+class Prefixes(commands.Cog, name="Configuration"):
+    """Per-guild command-prefix configuration.
+
+    The cog's display name ("Configuration") is the heading it gets in ``?help``.
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.hybrid_command(
+        name="setprefixes",
+        description="Show or set this server's text command prefixes",
+    )
+    @commands.guild_only()
+    @can_manage_prefixes()
+    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.describe(prefixes=SETPREFIXES_HELP)
+    async def setprefixes(self, ctx, *, prefixes: str = ""):
+        """Show or set this server's text command prefixes.
+
+        With no argument, shows the current prefixes. Otherwise sets them to the
+        given characters (e.g. `?/!`), or `none` to use only @-mention and slash
+        commands. The bot always also responds to @-mentions and its slash
+        commands regardless. Requires being the server owner, an administrator, or
+        having Manage Server.
+        """
+        # Acknowledge a slash interaction up front so the response can't miss the
+        # 3-second deadline; a no-op (typing) for text/mention invocations.
+        if ctx.interaction is not None:
+            await ctx.defer(ephemeral=True)
+
+        store = self.bot.prefix_store
+        guild_id = ctx.guild.id
+        arg = prefixes.strip()
+
+        if not arg:
+            await ctx.send(
+                f"Current prefixes: {describe(store.get(guild_id))}", ephemeral=True
+            )
+            return
+
+        if arg.lower() in CLEAR_WORDS:
+            store.set(guild_id, [])
+            logger.info("Guild %s cleared text prefixes", guild_id)
+            await ctx.send(f"Prefixes set to {describe([])}", ephemeral=True)
+            return
+
+        parsed = prefixstore.parse_prefixes(arg)
+        if not parsed:
+            await ctx.send(
+                "Give me one or more characters to use as prefixes (e.g. `?/!`), "
+                "or `none` for only @-mention and slash commands.",
+                ephemeral=True,
+            )
+            return
+
+        store.set(guild_id, parsed)
+        logger.info("Guild %s set prefixes to %s", guild_id, parsed)
+        await ctx.send(f"Prefixes set to {describe(parsed)}", ephemeral=True)
+
+    @setprefixes.error
+    async def setprefixes_error(self, ctx, error):
+        """Reply plainly when the check fails (wrong permission or used in a DM)."""
+        original = getattr(error, "original", error)
+        if isinstance(original, commands.NoPrivateMessage):
+            await ctx.send("That command only works in a server.", ephemeral=True)
+        elif isinstance(original, commands.CheckFailure):
+            await ctx.send(
+                "You need to be the server owner or have Administrator or "
+                "**Manage Server** to change prefixes.",
+                ephemeral=True,
+            )
+        else:
+            logger.error("setprefixes failed", exc_info=original)
+
+
+async def setup(bot):
+    """discord.py extension entry point: ensure a prefix store and register the cog.
+
+    ``main()`` normally attaches the real (file-backed) store to the bot before
+    startup; fall back to an in-memory store so the cog can be loaded on its own
+    (e.g. in tests).
+    """
+    if getattr(bot, "prefix_store", None) is None:
+        bot.prefix_store = prefixstore.PrefixStore(":memory:").load()
+    await bot.add_cog(Prefixes(bot))

--- a/prefixstore.py
+++ b/prefixstore.py
@@ -1,0 +1,137 @@
+#!.venv/bin/python3
+# MvKDiceBot: Discord bot for rolling dice for Mecha Vs Kaiju
+# Copyright (C) 2023  Eric Eisenhart
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# https://github.com/freiheit/MvKDiceBot
+"""Per-guild command-prefix storage for MvKDiceBot.
+
+Prefixes are cached in memory (read once at startup) and written through to a
+sqlite database whenever they change. The bot always also responds to @-mentions
+and to its slash commands, regardless of the configured text prefixes, so those
+are never stored here. A guild with no stored prefixes uses DEFAULT_PREFIXES.
+"""
+
+import logging
+import os
+import sqlite3
+
+logger = logging.getLogger(__name__)
+
+# The classic text prefixes. Used for DMs, and seeded onto the guilds the bot is
+# already in the first time it runs (see PrefixStore.backfill). A guild that has
+# never been configured otherwise gets *no* text prefixes (mention/slash only),
+# so newly-joined servers start clean.
+DEFAULT_PREFIXES = ("?", "/")
+
+# Cap on how many prefixes a guild may set, to keep things sane.
+MAX_PREFIXES = 10
+
+
+def parse_prefixes(text):
+    """Parse user input into an ordered, de-duplicated list of single-char prefixes.
+
+    Whitespace is ignored, so '?/!' and '? / !' both give ['?', '/', '!']. The
+    result is capped at MAX_PREFIXES. An empty/whitespace-only input gives [].
+    """
+    prefixes = []
+    for char in text:
+        if char.isspace():
+            continue
+        if char not in prefixes:
+            prefixes.append(char)
+    return prefixes[:MAX_PREFIXES]
+
+
+def format_prefixes(prefixes):
+    """Render a prefix list for display as space-separated inline code."""
+    return " ".join(f"`{p}`" for p in prefixes)
+
+
+class PrefixStore:
+    """In-memory per-guild prefix cache backed by a sqlite database.
+
+    Call :meth:`load` once at startup to open the database and populate the
+    cache; :meth:`set` writes through to the database as changes happen. Reads
+    (:meth:`get`) are served entirely from the cache, so they're cheap enough to
+    run for every incoming message.
+    """
+
+    def __init__(self, path):
+        self._path = path
+        self._cache = {}
+        self._conn = None
+        # True when load() created the database (no file existed) -- the signal
+        # for a one-time backfill of the guilds the bot is already in.
+        self.created = False
+
+    def load(self):
+        """Open the database (creating the table if needed) and cache all rows."""
+        # Check before connect(), which would create the file.
+        self.created = self._path == ":memory:" or not os.path.exists(self._path)
+        self._conn = sqlite3.connect(self._path)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS guild_prefixes "
+            "(guild_id INTEGER PRIMARY KEY, prefixes TEXT NOT NULL)"
+        )
+        self._conn.commit()
+        self._cache = {}
+        for guild_id, prefixes in self._conn.execute(
+            "SELECT guild_id, prefixes FROM guild_prefixes"
+        ):
+            # A stored empty string means "configured with no text prefixes"; keep
+            # the row so it stays distinct from a guild that was never configured.
+            self._cache[guild_id] = parse_prefixes(prefixes)
+        logger.info("Loaded prefixes for %d guild(s)", len(self._cache))
+        return self
+
+    def get(self, guild_id):
+        """Return a copy of the prefix list to use for a message's prefixes.
+
+        DMs (``guild_id is None``) use DEFAULT_PREFIXES. A configured guild uses
+        its stored list, which may be empty (only @-mention and slash commands).
+        An unconfigured guild also gets an empty list, so a server the bot joins
+        starts out mention/slash only.
+        """
+        if guild_id is None:
+            return list(DEFAULT_PREFIXES)
+        return list(self._cache.get(guild_id, []))
+
+    def set(self, guild_id, prefixes):
+        """Cache and persist the prefix list for a guild; return the stored list."""
+        prefixes = list(prefixes)
+        self._cache[guild_id] = prefixes
+        if self._conn is not None:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO guild_prefixes (guild_id, prefixes) "
+                "VALUES (?, ?)",
+                (guild_id, "".join(prefixes)),
+            )
+            self._conn.commit()
+        return prefixes
+
+    def backfill(self, guild_ids):
+        """Seed DEFAULT_PREFIXES for any of ``guild_ids`` not already configured.
+
+        Run once on first startup (a freshly-created database) so the guilds the
+        bot is already in keep the classic ``?``/``/`` prefixes, while guilds it
+        joins afterwards start with none. Returns how many guilds were seeded.
+        """
+        count = 0
+        for guild_id in guild_ids:
+            if guild_id not in self._cache:
+                self.set(guild_id, DEFAULT_PREFIXES)
+                count += 1
+        return count

--- a/test.py
+++ b/test.py
@@ -19,14 +19,22 @@
 """Test module for MvKDiceBot"""
 
 import asyncio
+import os
 import random
 import re
 import sys
+import tempfile
 import unittest
+from types import SimpleNamespace
+
+import discord
+from discord.ext import commands
 
 import escalationcog
 import mvkdicebot
 import mvkroller as roller
+import prefixcog
+import prefixstore
 import rollcog
 
 
@@ -432,7 +440,7 @@ class TestBotCommands(unittest.TestCase):
 
     def test_prefix_commands_registered(self):
         """The primary command names resolve as text/prefix commands."""
-        for name in ("mvkroll", "plainroll"):
+        for name in ("mvkroll", "plainroll", "setprefixes"):
             with self.subTest(name=name):
                 self.assertIsNotNone(mvkdicebot.bot.get_command(name))
 
@@ -467,6 +475,7 @@ class TestBotCommands(unittest.TestCase):
             "esc",
             "nextround",
             "n",
+            "setprefixes",
         ):
             with self.subTest(name=name):
                 self.assertIn(name, app_names)
@@ -611,6 +620,103 @@ class TestEscalation(unittest.TestCase):
         maxed = escalationcog.format_value(escalationcog.MAX_VALUE)
         self.assertIn(":six:", maxed)
         self.assertIn("maximum", maxed)
+
+
+class TestPrefixStore(unittest.TestCase):
+    """Test per-guild prefix parsing and the sqlite-backed store."""
+
+    def test_parse_prefixes(self):
+        """Whitespace is ignored, order/dedup preserved, count capped."""
+        self.assertEqual(prefixstore.parse_prefixes("?/!"), ["?", "/", "!"])
+        self.assertEqual(prefixstore.parse_prefixes("? / !"), ["?", "/", "!"])
+        self.assertEqual(prefixstore.parse_prefixes("??//"), ["?", "/"])
+        self.assertEqual(prefixstore.parse_prefixes(""), [])
+        self.assertEqual(prefixstore.parse_prefixes("   "), [])
+        capped = prefixstore.parse_prefixes("abcdefghijklmnop")
+        self.assertEqual(len(capped), prefixstore.MAX_PREFIXES)
+
+    def test_format_prefixes(self):
+        """Prefixes render as space-separated inline code."""
+        self.assertEqual(prefixstore.format_prefixes(["?", "/"]), "`?` `/`")
+
+    def test_get_dm_defaults_and_unconfigured_guild_empty(self):
+        """DMs use the defaults; an unconfigured guild gets no text prefixes."""
+        store = prefixstore.PrefixStore(":memory:").load()
+        self.assertEqual(store.get(None), list(prefixstore.DEFAULT_PREFIXES))
+        self.assertEqual(store.get(123), [])
+
+    def test_set_and_get_roundtrip(self):
+        """A set value is returned for that guild but not others."""
+        store = prefixstore.PrefixStore(":memory:").load()
+        store.set(42, ["!", "."])
+        self.assertEqual(store.get(42), ["!", "."])
+        self.assertEqual(store.get(99), [])  # unconfigured guild -> mention/slash only
+        # Returned lists are copies, so a caller can't mutate the cache.
+        store.get(42).append("x")
+        self.assertEqual(store.get(42), ["!", "."])
+
+    def test_persists_across_reload(self):
+        """Values written to a file are reloaded by a fresh store."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "prefixes.sqlite3")
+            store = prefixstore.PrefixStore(path).load()
+            store.set(7, ["!", "?"])
+
+            reopened = prefixstore.PrefixStore(path).load()
+            self.assertEqual(reopened.get(7), ["!", "?"])
+
+    def test_created_flag(self):
+        """``created`` is True for a fresh/in-memory DB, False once the file exists."""
+        self.assertTrue(prefixstore.PrefixStore(":memory:").load().created)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "prefixes.sqlite3")
+            self.assertTrue(prefixstore.PrefixStore(path).load().created)
+            self.assertFalse(prefixstore.PrefixStore(path).load().created)
+
+    def test_backfill_only_unconfigured(self):
+        """backfill seeds defaults for new guilds, leaving configured ones (incl. empty)."""
+        store = prefixstore.PrefixStore(":memory:").load()
+        store.set(1, ["!"])  # already configured
+        store.set(2, [])  # explicitly cleared -- must stay empty
+        seeded = store.backfill([1, 2, 3])
+        self.assertEqual(seeded, 1)  # only guild 3
+        self.assertEqual(store.get(1), ["!"])
+        self.assertEqual(store.get(2), [])
+        self.assertEqual(store.get(3), list(prefixstore.DEFAULT_PREFIXES))
+
+
+class TestPrefixPermissions(unittest.TestCase):
+    """Who may run setprefixes: owner, admin, or Manage Server; nobody else."""
+
+    @staticmethod
+    def _ctx(uid, perms, owner=1, in_guild=True):
+        return SimpleNamespace(
+            author=SimpleNamespace(id=uid, guild_permissions=perms),
+            guild=SimpleNamespace(owner_id=owner) if in_guild else None,
+        )
+
+    def test_owner_admin_manage_allowed(self):
+        """The owner (even with no role perms), admins, and Manage Server pass."""
+        cases = [
+            (1, discord.Permissions.none()),  # owner, no role perms
+            (2, discord.Permissions(administrator=True)),
+            (3, discord.Permissions(manage_guild=True)),
+        ]
+        for uid, perms in cases:
+            with self.subTest(uid=uid):
+                self.assertTrue(prefixcog.may_manage_prefixes(self._ctx(uid, perms)))
+
+    def test_plain_member_denied(self):
+        """A member without the needed permissions is rejected."""
+        ctx = self._ctx(4, discord.Permissions(send_messages=True))
+        with self.assertRaises(commands.MissingPermissions):
+            prefixcog.may_manage_prefixes(ctx)
+
+    def test_dm_denied(self):
+        """There's no guild to configure in a DM."""
+        ctx = self._ctx(1, discord.Permissions.all(), in_guild=False)
+        with self.assertRaises(commands.NoPrivateMessage):
+            prefixcog.may_manage_prefixes(ctx)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Pass 2 of 2 on configurable prefixes (Pass 1 added `/` as a default text prefix, #151).

Each guild gets its own set of text command prefixes, stored in sqlite (loaded once at startup, written through on change). @-mention and slash commands always work regardless.

## Behavior
- **`/setprefixes`** (also `?setprefixes` / `@MvkDiceBot setprefixes` — it's a hybrid command) shows or sets the server's prefixes:
  - no argument → shows the current set
  - characters (e.g. `?/!`) → replaces the set (whitespace ignored, deduped, capped at 10)
  - `none` (or `clear`/`off`) → only @-mention and slash commands
- **Permissions:** restricted to the **guild owner, administrators, or members with Manage Server** (`may_manage_prefixes`). Non-permitted members get a clear message; `?help` only lists it for those who can use it.
- **Defaults / migration:** DMs use `?`/`/`. On first run (a brand-new database) the bot seeds `?`/`/` onto the guilds it's already in, so existing servers keep working; a guild the bot joins later starts with **no** text prefixes (mention/slash only) until configured. An explicitly-cleared (empty) set is stored and stays distinct from "never configured".
- **Help:** the section is titled **Configuration** and is pinned last in `?help`.

## Implementation
- `prefixstore.py` — `PrefixStore` (in-memory cache + sqlite write-through), `parse_prefixes`/`format_prefixes`, `DEFAULT_PREFIXES`, `backfill`. No Discord deps.
- `prefixcog.py` — `Configuration` cog with the hybrid `setprefixes` command, `may_manage_prefixes` check, defers the slash response up front, local error handler for permission/DM failures.
- `mvkdicebot.py` — async `get_prefix` resolver reads `bot.prefix_store`; store created in `main()` from config; first-run backfill in `on_ready`; friendly permission message in `on_app_command_error`.
- `mvkconfig.py` — `get_database_path()` (config `MAIN.database`, default `mvkdicebot.sqlite3`, gitignored).
- `helpcog.py` — `send_bot_help` override to pin the Configuration section last.

## Tests
60 unit tests pass (added `TestPrefixStore`, `TestPrefixPermissions`, and registration/tree checks). pylint 10/10, ruff clean. Verified live on the dev bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)