### PR TITLE
Add anyroll command for arbitrary die sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ to @-mentions and to its slash commands regardless.
   d20 it also calls out 13th Age-flavored results (crit, fumble, even/odd,
   possible two-weapon hit) and, when this channel's escalation die is set, shows
   it and an escalation-adjusted total. Also available as the slash command `/p`.
+- `anyroll` — like `plainroll` but with no die-size restriction, so `d100`,
+  `3d3`, `d7`, `d2`, etc. all work. Rolls the pool, applies `+N`/`-N` modifiers,
+  and gives a total — no MvK/13th Age rules or crit/even/odd callouts. Aliases
+  `a`, `rollany`; also the slash command `/a`.
 - `escalation` — tracks the 13th Age escalation die (0–6) for the current
   channel. `?escalation`/`/escalation` (text aliases `?esc`/`?e`, plus the `/esc`
   slash command) shows it; `+1`/`next` advances a round, `-1`/`back` steps down,

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -32,9 +32,12 @@ import re
 from rollcommon import (
     NUMBER_EMOJI,
     RollError,
+    merge_any,
     merge_rolls,
+    parse_any_dice,
     parse_dice,
     print_dice,
+    roll_any,
     roll_dice,
 )
 from rollmvkhelpers import (
@@ -318,5 +321,33 @@ def plainroll(dicestr: str, escalation: int = 0, prior_rolls=None):
     lines.append(f"**Total: {total}**")
     if show_escalation:
         lines.append(f"**w/Esc: {total + escalation}**")
+
+    return "\n".join(lines) + "\n", dicerolls
+
+
+def anyroll(dicestr: str, prior_rolls=None):
+    """Roll a pool of dice of ANY size (d2, d3, d7, d100, ...), plus +/- modifiers.
+
+    Like ``plainroll`` but with no die-size restriction and none of the d20
+    special callouts or escalation die -- just the dice and a total. Returns
+    ``(text, rolls)``; passing a previous ``rolls`` as ``prior_rolls`` reuses
+    those dice and only rolls newly-added ones (for edited rolls).
+    """
+
+    logger.debug("Roll %s", {dicestr})
+
+    add_amount = parse_math(dicestr)
+    dicecounts = parse_any_dice(dicestr)
+    if prior_rolls is None:
+        dicerolls = roll_any(dicecounts)
+    else:
+        dicerolls = merge_any(prior_rolls, dicecounts)
+
+    total = sum(sum(values) for values in dicerolls.values()) + add_amount
+
+    lines = [f"-# {print_dice(dicerolls).rstrip()}"]
+    if add_amount != 0:
+        lines.append(f"-# Adjustment: {add_amount}")
+    lines.append(f"**Total: {total}**")
 
     return "\n".join(lines) + "\n", dicerolls

--- a/rollcog.py
+++ b/rollcog.py
@@ -34,6 +34,7 @@ MVK_DICE_HELP = (
     "boost/reduce dN, burnout, unstable, burst, +N, impact+N, vs N (see ?help)."
 )
 PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
+ANY_DICE_HELP = "Any dice (d2, d3, d7, d100, ...) plus +N/-N modifiers, e.g. 'd100 +17'"
 
 # How many recent text rolls to remember (message -> our reply) for edit handling.
 MAX_TRACKED = 200
@@ -226,8 +227,29 @@ class Roll(commands.Cog, name="Dice Rolling"):
         else:
             await self._run_slash_roll(ctx.interaction, roller, dicestr)
 
-    # Discord application commands have no alias mechanism, so the short '/r' and
-    # '/p' forms are registered as their own slash commands that reuse the rollers.
+    @commands.hybrid_command(
+        aliases=["a", "rollany"],
+        brief="Rolls any dice (d2, d3, d7, d100, ...) and totals them.",
+        description="Roll any dice and total them",
+    )
+    @app_commands.describe(dicestr=ANY_DICE_HELP)
+    async def anyroll(self, ctx, *, dicestr: str):
+        """Rolls a pool of dice of any size, plus `+N`/`-N` modifiers.
+
+        Unlike `plainroll` it doesn't restrict die sizes, so `d100`, `3d3`, `d7`,
+        `d2`, and so on all work. It just totals the dice and modifiers, with no
+        special MvK or 13th Age rules and no crit/even/odd callouts.
+        Example: `anyroll d100 +17`
+        Example: `anyroll 3d3 d6`
+        """
+        if ctx.interaction is None:
+            await self._run_text_roll(ctx, mvkroller.anyroll, dicestr)
+        else:
+            await self._run_slash_roll(ctx.interaction, mvkroller.anyroll, dicestr)
+
+    # Discord application commands have no alias mechanism, so the short '/r',
+    # '/p', and '/a' forms are registered as their own slash commands that reuse
+    # the rollers.
     @app_commands.command(
         name="r", description="Roll a dice pool with MvK rules math (same as /mvkroll)"
     )
@@ -246,6 +268,14 @@ class Roll(commands.Cog, name="Dice Rolling"):
         """Slash-command alias (/p) for /plainroll."""
         roller = self._plainroller(interaction.channel_id)
         await self._run_slash_roll(interaction, roller, dicestr)
+
+    @app_commands.command(
+        name="a", description="Roll any dice and total them (same as /anyroll)"
+    )
+    @app_commands.describe(dicestr=ANY_DICE_HELP)
+    async def anyroll_slash_alias(self, interaction: discord.Interaction, dicestr: str):
+        """Slash-command alias (/a) for /anyroll."""
+        await self._run_slash_roll(interaction, mvkroller.anyroll, dicestr)
 
     @commands.Cog.listener()
     async def on_message_edit(self, before, after):

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -146,6 +146,74 @@ def merge_rolls(prior, dicecounts, rand_source=None):
     return dicerolls
 
 
+def parse_any_dice(dicestr: str):
+    """Parse a dice string allowing ANY die size (d2, d3, d7, d100, ...).
+
+    Same ``NdN``/pool/whitespace handling as ``parse_dice`` but without the
+    d4-d20 restriction. Returns ``{size: count}`` ordered largest-die-first;
+    a size below 1 (e.g. ``d0``) raises ``RollError``.
+    """
+    pattern_ndn = re.compile(r"([0-9]*) *[dD]([0-9]+)")
+
+    counts = {}
+    try:
+        for count, size in re.findall(pattern_ndn, dicestr):
+            size = int(size)
+            if size < 1:
+                raise RollError(f"Invalid dice size d{size}")
+            num = int(count) if count else 1
+            counts[size] = counts.get(size, 0) + num
+    except RollError:
+        raise
+    except Exception as exc:
+        raise RollError("Exception while parsing dice.") from exc
+
+    return {size: counts[size] for size in sorted(counts, reverse=True)}
+
+
+def roll_any(dicecounts, rand_source=None):
+    """Roll a pool of arbitrary-sized dice.
+
+    Returns ``{size: [rolls]}`` for each size with a positive count, preserving
+    ``dicecounts``'s order (unlike ``roll_dice``, no fixed d4-d20 keys are added).
+    """
+    if rand_source is None:
+        rand_source = random.Random()
+    try:
+        return {
+            size: [_roll_one(size, rand_source) for _ in range(num)]
+            for size, num in dicecounts.items()
+            if num > 0
+        }
+    except Exception as exc:
+        raise RollError("Exception while rolling dice.") from exc
+
+
+def merge_any(prior, dicecounts, rand_source=None):
+    """Arbitrary-size counterpart to ``merge_rolls`` for editing ``anyroll``.
+
+    Keeps prior rolls per size and rolls only newly-added dice (and keeps a
+    random subset when a count drops), over the union of sizes in ``prior`` and
+    ``dicecounts``, ordered largest-die-first. Sizes that end up empty are omitted.
+    """
+    if rand_source is None:
+        rand_source = random.Random()
+    try:
+        merged = {}
+        for size in sorted(set(prior) | set(dicecounts), reverse=True):
+            want = dicecounts.get(size, 0)
+            have = list(prior.get(size, []))
+            kept = rand_source.sample(have, want) if want < len(have) else have
+            rolled = kept + [
+                _roll_one(size, rand_source) for _ in range(want - len(kept))
+            ]
+            if rolled:
+                merged[size] = rolled
+        return merged
+    except Exception as exc:
+        raise RollError("Exception while merging dice rolls.") from exc
+
+
 def print_dice(dicerolls):
     "Creates a string rep of the rolled dice"
     answer = "Dice: "

--- a/test.py
+++ b/test.py
@@ -418,6 +418,53 @@ class TestRoller(unittest.TestCase):
         self.assertTrue(any(line.startswith("Choose:") for line in lines))
 
 
+class TestAnyRoll(unittest.TestCase):
+    """Tests for anyroll: any die size, pools, modifiers, total (no special rules)."""
+
+    def test_parse_any_dice(self):
+        """Any die size is accepted, pools aggregate, result is largest-die-first."""
+        self.assertEqual(roller.parse_any_dice("3d3 d100 +17"), {100: 1, 3: 3})
+        self.assertEqual(roller.parse_any_dice("d7 d2 2d3"), {7: 1, 3: 2, 2: 1})
+        self.assertEqual(roller.parse_any_dice("d20 2d6"), {20: 1, 6: 2})
+        self.assertEqual(roller.parse_any_dice(""), {})
+
+    def test_parse_any_dice_bad_size(self):
+        """A die below 1 (e.g. d0) is rejected."""
+        with self.assertRaises(roller.RollError):
+            roller.parse_any_dice("d0")
+
+    def test_roll_any(self):
+        """roll_any rolls each size in range and only includes positive counts."""
+        out = roller.roll_any({100: 1, 3: 2, 8: 0}, random.Random(7))
+        self.assertEqual(set(out), {100, 3})  # d8 with count 0 omitted
+        self.assertEqual(len(out[3]), 2)
+        self.assertTrue(1 <= out[100][0] <= 100)
+        self.assertTrue(all(1 <= v <= 3 for v in out[3]))
+
+    def test_merge_any_keeps_prior_and_rolls_extra(self):
+        """Editing reuses prior dice and only rolls the newly-added ones."""
+        merged = roller.merge_any({3: [1, 2]}, {3: 3}, random.Random(0))
+        self.assertEqual(len(merged[3]), 3)
+        self.assertEqual(merged[3][:2], [1, 2])
+        self.assertTrue(1 <= merged[3][2] <= 3)
+        # Unchanged count reuses everything (no reroll).
+        self.assertEqual(roller.merge_any({100: [42]}, {100: 1})[100], [42])
+
+    def test_anyroll_output(self):
+        """anyroll formats like plainroll: -# Dice, optional -# Adjustment, **Total**."""
+        text, rolls = roller.anyroll("d100 +17", prior_rolls={100: [42]})
+        self.assertEqual(rolls, {100: [42]})
+        self.assertIn("-# Dice: 1d100[42]", text)
+        self.assertIn("-# Adjustment: 17", text)
+        self.assertIn("**Total: 59**", text)
+        # No modifier -> no Adjustment line; no crit/even/odd/escalation callouts.
+        text, _ = roller.anyroll("3d3", prior_rolls={3: [1, 2, 3]})
+        self.assertIn("-# Dice: 3d3[1, 2, 3]", text)
+        self.assertIn("**Total: 6**", text)
+        self.assertNotIn("Adjustment", text)
+        self.assertNotIn("Esc", text)
+
+
 class TestBotCommands(unittest.TestCase):
     """Test that the bot exposes both prefix and slash (app) commands.
 
@@ -440,7 +487,7 @@ class TestBotCommands(unittest.TestCase):
 
     def test_prefix_commands_registered(self):
         """The primary command names resolve as text/prefix commands."""
-        for name in ("mvkroll", "plainroll", "setprefixes"):
+        for name in ("mvkroll", "plainroll", "anyroll", "setprefixes"):
             with self.subTest(name=name):
                 self.assertIsNotNone(mvkdicebot.bot.get_command(name))
 
@@ -451,6 +498,8 @@ class TestBotCommands(unittest.TestCase):
             "roll": "mvkroll",
             "p": "plainroll",
             "justroll": "plainroll",
+            "a": "anyroll",
+            "rollany": "anyroll",
             "esc": "escalation",
             "e": "escalation",
             "next": "nextround",
@@ -468,9 +517,11 @@ class TestBotCommands(unittest.TestCase):
         for name in (
             "mvkroll",
             "plainroll",
+            "anyroll",
             "help",
             "r",
             "p",
+            "a",
             "escalation",
             "esc",
             "nextround",


### PR DESCRIPTION
Adds a new `anyroll` command (aliases `a`, `rollany`; slash `/anyroll` and `/a`).

It's like `plainroll` but with **no die-size restriction**, so `d100`, `3d3`, `d7`, `d2`, etc. all work. It rolls the pool, applies `+N`/`-N` modifiers, and prints a total — with **no** MvK/13th Age rules and **none** of the crit/fumble/even/odd callouts or escalation die. Output format matches `plainroll` (`-# Dice:` / `-# Adjustment:` / `**Total:**`), sizes listed largest-first.

## Implementation
- `rollcommon.py`: `parse_any_dice` (any size, pools aggregated, largest-first, rejects `d0`), `roll_any`, and `merge_any` (edit-aware, like the standard helpers but size-agnostic). The existing d4–d20 `parse_dice`/`roll_dice`/`merge_rolls` path is untouched.
- `mvkroller.py`: `anyroll(dicestr, prior_rolls=None)` → `(text, rolls)`, mirroring `plainroll`'s formatting minus the special bits.
- `rollcog.py`: `anyroll` hybrid command (aliases `a`, `rollany`) + `/a` slash alias, reusing the existing `_run_text_roll`/`_run_slash_roll` machinery (so editing a text roll re-rolls only added dice). Shows under "Dice Rolling" in `?help`.

## Tests
65 unit tests pass (added `TestAnyRoll` covering parse/roll/merge/output and command registration). pylint 10/10, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)