### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/freiheit/MvKDiceBot/security/code-scanning/3](https://github.com/freiheit/MvKDiceBot/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/test.yml` so the workflow does not inherit potentially broad defaults.  
Best fix without changing functionality: define workflow-level permissions with the minimum required scope:

- Add at root (after `on`):  
  `permissions:`  
  `  contents: read`

This supports `actions/checkout` while keeping token access minimal for this test-only workflow. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
