### PR TITLE
Add anyroll and average commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ to @-mentions and to its slash commands regardless.
   d20 it also calls out 13th Age-flavored results (crit, fumble, even/odd,
   possible two-weapon hit) and, when this channel's escalation die is set, shows
   it and an escalation-adjusted total. Also available as the slash command `/p`.
+- `anyroll` — like `plainroll` but with no die-size restriction, so `d100`,
+  `3d3`, `d7`, `d2`, etc. all work. Rolls the pool, applies `+N`/`-N` modifiers,
+  and gives a total — no MvK/13th Age rules or crit/even/odd callouts. Aliases
+  `a`, `rollany`; also the slash command `/a`.
 - `escalation` — tracks the 13th Age escalation die (0–6) for the current
   channel. `?escalation`/`/escalation` (text aliases `?esc`/`?e`, plus the `/esc`
   slash command) shows it; `+1`/`next` advances a round, `-1`/`back` steps down,

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ to @-mentions and to its slash commands regardless.
   `3d3`, `d7`, `d2`, etc. all work. Rolls the pool, applies `+N`/`-N` modifiers,
   and gives a total — no MvK/13th Age rules or crit/even/odd callouts. Aliases
   `a`, `rollany`; also the slash command `/a`.
+- `average` — totals the *average* result of a standard dice pool (d20–d4) plus
+  `+N`/`-N` modifiers, instead of rolling. Each die averages to half its max +
+  0.5 (d4 → 2.5, d20 → 10.5). 13th Age uses this for damage and recovery rolls
+  (never attack or skill checks). Aliases `mean`, `m`; also the slash command
+  `/m`.
 - `escalation` — tracks the 13th Age escalation die (0–6) for the current
   channel. `?escalation`/`/escalation` (text aliases `?esc`/`?e`, plus the `/esc`
   slash command) shows it; `+1`/`next` advances a round, `-1`/`back` steps down,

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -351,3 +351,35 @@ def anyroll(dicestr: str, prior_rolls=None):
     lines.append(f"**Total: {total}**")
 
     return "\n".join(lines) + "\n", dicerolls
+
+
+def average(dicestr: str, prior_rolls=None):  # pylint: disable=unused-argument
+    """Total the *average* result of a dice pool instead of rolling it.
+
+    Accepts the standard dice (d20-d4, same as plainroll) plus +/- modifiers.
+    Each die averages to half its max + 0.5 (d4 -> 2.5, d20 -> 10.5), so the
+    result is whole or ends in .5. 13th Age uses averages for damage and recovery
+    rolls (never attack or skill checks). Returns ``(text, {})`` -- nothing is
+    rolled, so there's no per-die state to reuse on an edit; ``prior_rolls`` is
+    accepted (and ignored) for a uniform roller signature.
+    """
+
+    logger.debug("Average %s", {dicestr})
+
+    add_amount = parse_math(dicestr)
+    dicecounts = parse_dice(dicestr)
+
+    mean = sum(count * (size + 1) / 2 for size, count in dicecounts.items())
+    total = mean + add_amount
+    # Each die's mean ends in .5, so a pool total is whole or .5; show it tidily.
+    shown = int(total) if total == int(total) else total
+
+    pool = " ".join(
+        f"{count}d{size}" for size, count in dicecounts.items() if count > 0
+    )
+    lines = [f"-# Dice: {pool}"] if pool else []
+    if add_amount != 0:
+        lines.append(f"-# Adjustment: {add_amount}")
+    lines.append(f"**Average: {shown}**")
+
+    return "\n".join(lines) + "\n", {}

--- a/mvkroller.py
+++ b/mvkroller.py
@@ -32,9 +32,12 @@ import re
 from rollcommon import (
     NUMBER_EMOJI,
     RollError,
+    merge_any,
     merge_rolls,
+    parse_any_dice,
     parse_dice,
     print_dice,
+    roll_any,
     roll_dice,
 )
 from rollmvkhelpers import (
@@ -318,5 +321,33 @@ def plainroll(dicestr: str, escalation: int = 0, prior_rolls=None):
     lines.append(f"**Total: {total}**")
     if show_escalation:
         lines.append(f"**w/Esc: {total + escalation}**")
+
+    return "\n".join(lines) + "\n", dicerolls
+
+
+def anyroll(dicestr: str, prior_rolls=None):
+    """Roll a pool of dice of ANY size (d2, d3, d7, d100, ...), plus +/- modifiers.
+
+    Like ``plainroll`` but with no die-size restriction and none of the d20
+    special callouts or escalation die -- just the dice and a total. Returns
+    ``(text, rolls)``; passing a previous ``rolls`` as ``prior_rolls`` reuses
+    those dice and only rolls newly-added ones (for edited rolls).
+    """
+
+    logger.debug("Roll %s", {dicestr})
+
+    add_amount = parse_math(dicestr)
+    dicecounts = parse_any_dice(dicestr)
+    if prior_rolls is None:
+        dicerolls = roll_any(dicecounts)
+    else:
+        dicerolls = merge_any(prior_rolls, dicecounts)
+
+    total = sum(sum(values) for values in dicerolls.values()) + add_amount
+
+    lines = [f"-# {print_dice(dicerolls).rstrip()}"]
+    if add_amount != 0:
+        lines.append(f"-# Adjustment: {add_amount}")
+    lines.append(f"**Total: {total}**")
 
     return "\n".join(lines) + "\n", dicerolls

--- a/rollcog.py
+++ b/rollcog.py
@@ -34,6 +34,7 @@ MVK_DICE_HELP = (
     "boost/reduce dN, burnout, unstable, burst, +N, impact+N, vs N (see ?help)."
 )
 PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
+ANY_DICE_HELP = "Any dice (d2, d3, d7, d100, ...) plus +N/-N modifiers, e.g. 'd100 +17'"
 
 # How many recent text rolls to remember (message -> our reply) for edit handling.
 MAX_TRACKED = 200
@@ -226,8 +227,29 @@ class Roll(commands.Cog, name="Dice Rolling"):
         else:
             await self._run_slash_roll(ctx.interaction, roller, dicestr)
 
-    # Discord application commands have no alias mechanism, so the short '/r' and
-    # '/p' forms are registered as their own slash commands that reuse the rollers.
+    @commands.hybrid_command(
+        aliases=["a", "rollany"],
+        brief="Rolls any dice (d2, d3, d7, d100, ...) and totals them.",
+        description="Roll any dice and total them",
+    )
+    @app_commands.describe(dicestr=ANY_DICE_HELP)
+    async def anyroll(self, ctx, *, dicestr: str):
+        """Rolls a pool of dice of any size, plus `+N`/`-N` modifiers.
+
+        Unlike `plainroll` it doesn't restrict die sizes, so `d100`, `3d3`, `d7`,
+        `d2`, and so on all work. It just totals the dice and modifiers, with no
+        special MvK or 13th Age rules and no crit/even/odd callouts.
+        Example: `anyroll d100 +17`
+        Example: `anyroll 3d3 d6`
+        """
+        if ctx.interaction is None:
+            await self._run_text_roll(ctx, mvkroller.anyroll, dicestr)
+        else:
+            await self._run_slash_roll(ctx.interaction, mvkroller.anyroll, dicestr)
+
+    # Discord application commands have no alias mechanism, so the short '/r',
+    # '/p', and '/a' forms are registered as their own slash commands that reuse
+    # the rollers.
     @app_commands.command(
         name="r", description="Roll a dice pool with MvK rules math (same as /mvkroll)"
     )
@@ -246,6 +268,14 @@ class Roll(commands.Cog, name="Dice Rolling"):
         """Slash-command alias (/p) for /plainroll."""
         roller = self._plainroller(interaction.channel_id)
         await self._run_slash_roll(interaction, roller, dicestr)
+
+    @app_commands.command(
+        name="a", description="Roll any dice and total them (same as /anyroll)"
+    )
+    @app_commands.describe(dicestr=ANY_DICE_HELP)
+    async def anyroll_slash_alias(self, interaction: discord.Interaction, dicestr: str):
+        """Slash-command alias (/a) for /anyroll."""
+        await self._run_slash_roll(interaction, mvkroller.anyroll, dicestr)
 
     @commands.Cog.listener()
     async def on_message_edit(self, before, after):

--- a/rollcog.py
+++ b/rollcog.py
@@ -35,6 +35,7 @@ MVK_DICE_HELP = (
 )
 PLAIN_DICE_HELP = "Dice to roll plus +N/-N modifiers, e.g. '1d20 2d10 d8 +5'"
 ANY_DICE_HELP = "Any dice (d2, d3, d7, d100, ...) plus +N/-N modifiers, e.g. 'd100 +17'"
+AVERAGE_DICE_HELP = "Standard dice to average plus +N/-N modifiers, e.g. '2d6 +3'"
 
 # How many recent text rolls to remember (message -> our reply) for edit handling.
 MAX_TRACKED = 200
@@ -247,9 +248,29 @@ class Roll(commands.Cog, name="Dice Rolling"):
         else:
             await self._run_slash_roll(ctx.interaction, mvkroller.anyroll, dicestr)
 
+    @commands.hybrid_command(
+        name="average",
+        aliases=["mean", "m"],
+        brief="Averages a dice pool instead of rolling it (d20 → 10.5).",
+        description="Show the average result of a dice pool",
+    )
+    @app_commands.describe(dicestr=AVERAGE_DICE_HELP)
+    async def average(self, ctx, *, dicestr: str):
+        """Totals the *average* result of a dice pool instead of rolling it.
+
+        Accepts the standard dice (d20, d12, d10, d8, d6, d4) plus `+N`/`-N`
+        modifiers. Each die averages to half its max + 0.5 (d4 → 2.5, d20 → 10.5).
+        13th Age uses this for damage and recovery rolls (never attack or skill
+        checks). Example: `average 2d6 +3`
+        """
+        if ctx.interaction is None:
+            await self._run_text_roll(ctx, mvkroller.average, dicestr)
+        else:
+            await self._run_slash_roll(ctx.interaction, mvkroller.average, dicestr)
+
     # Discord application commands have no alias mechanism, so the short '/r',
-    # '/p', and '/a' forms are registered as their own slash commands that reuse
-    # the rollers.
+    # '/p', '/a', and '/m' forms are registered as their own slash commands that
+    # reuse the rollers.
     @app_commands.command(
         name="r", description="Roll a dice pool with MvK rules math (same as /mvkroll)"
     )
@@ -276,6 +297,14 @@ class Roll(commands.Cog, name="Dice Rolling"):
     async def anyroll_slash_alias(self, interaction: discord.Interaction, dicestr: str):
         """Slash-command alias (/a) for /anyroll."""
         await self._run_slash_roll(interaction, mvkroller.anyroll, dicestr)
+
+    @app_commands.command(
+        name="m", description="Average a dice pool (same as /average)"
+    )
+    @app_commands.describe(dicestr=AVERAGE_DICE_HELP)
+    async def average_slash_alias(self, interaction: discord.Interaction, dicestr: str):
+        """Slash-command alias (/m) for /average."""
+        await self._run_slash_roll(interaction, mvkroller.average, dicestr)
 
     @commands.Cog.listener()
     async def on_message_edit(self, before, after):

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -146,6 +146,74 @@ def merge_rolls(prior, dicecounts, rand_source=None):
     return dicerolls
 
 
+def parse_any_dice(dicestr: str):
+    """Parse a dice string allowing ANY die size (d2, d3, d7, d100, ...).
+
+    Same ``NdN``/pool/whitespace handling as ``parse_dice`` but without the
+    d4-d20 restriction. Returns ``{size: count}`` ordered largest-die-first;
+    a size below 1 (e.g. ``d0``) raises ``RollError``.
+    """
+    pattern_ndn = re.compile(r"([0-9]*) *[dD]([0-9]+)")
+
+    counts = {}
+    try:
+        for count, size in re.findall(pattern_ndn, dicestr):
+            size = int(size)
+            if size < 1:
+                raise RollError(f"Invalid dice size d{size}")
+            num = int(count) if count else 1
+            counts[size] = counts.get(size, 0) + num
+    except RollError:
+        raise
+    except Exception as exc:
+        raise RollError("Exception while parsing dice.") from exc
+
+    return {size: counts[size] for size in sorted(counts, reverse=True)}
+
+
+def roll_any(dicecounts, rand_source=None):
+    """Roll a pool of arbitrary-sized dice.
+
+    Returns ``{size: [rolls]}`` for each size with a positive count, preserving
+    ``dicecounts``'s order (unlike ``roll_dice``, no fixed d4-d20 keys are added).
+    """
+    if rand_source is None:
+        rand_source = random.Random()
+    try:
+        return {
+            size: [_roll_one(size, rand_source) for _ in range(num)]
+            for size, num in dicecounts.items()
+            if num > 0
+        }
+    except Exception as exc:
+        raise RollError("Exception while rolling dice.") from exc
+
+
+def merge_any(prior, dicecounts, rand_source=None):
+    """Arbitrary-size counterpart to ``merge_rolls`` for editing ``anyroll``.
+
+    Keeps prior rolls per size and rolls only newly-added dice (and keeps a
+    random subset when a count drops), over the union of sizes in ``prior`` and
+    ``dicecounts``, ordered largest-die-first. Sizes that end up empty are omitted.
+    """
+    if rand_source is None:
+        rand_source = random.Random()
+    try:
+        merged = {}
+        for size in sorted(set(prior) | set(dicecounts), reverse=True):
+            want = dicecounts.get(size, 0)
+            have = list(prior.get(size, []))
+            kept = rand_source.sample(have, want) if want < len(have) else have
+            rolled = kept + [
+                _roll_one(size, rand_source) for _ in range(want - len(kept))
+            ]
+            if rolled:
+                merged[size] = rolled
+        return merged
+    except Exception as exc:
+        raise RollError("Exception while merging dice rolls.") from exc
+
+
 def print_dice(dicerolls):
     "Creates a string rep of the rolled dice"
     answer = "Dice: "

--- a/test.py
+++ b/test.py
@@ -465,6 +465,32 @@ class TestAnyRoll(unittest.TestCase):
         self.assertNotIn("Esc", text)
 
 
+class TestAverage(unittest.TestCase):
+    """Tests for the average command: per-die mean (size+1)/2, modifiers, total."""
+
+    def test_average_single_die(self):
+        """A single die shows its exact mean (half max + 0.5)."""
+        text, rolls = roller.average("d20")
+        self.assertEqual(rolls, {})
+        self.assertIn("-# Dice: 1d20", text)
+        self.assertIn("**Average: 10.5**", text)
+        self.assertIn("**Average: 2.5**", roller.average("d4")[0])
+
+    def test_average_pool_and_modifier(self):
+        """Pools sum, modifiers apply, whole results drop the .0."""
+        text, _ = roller.average("2d6 +3")  # 7 + 3 = 10
+        self.assertIn("-# Dice: 2d6", text)
+        self.assertIn("-# Adjustment: 3", text)
+        self.assertIn("**Average: 10**", text)
+        # d20 + d6 = 10.5 + 3.5 = 14 (whole)
+        self.assertIn("**Average: 14**", roller.average("d20 d6")[0])
+
+    def test_average_rejects_nonstandard_dice(self):
+        """Like plainroll, only standard d4-d20 dice are accepted."""
+        with self.assertRaises(roller.RollError):
+            roller.average("d7")
+
+
 class TestBotCommands(unittest.TestCase):
     """Test that the bot exposes both prefix and slash (app) commands.
 
@@ -487,7 +513,7 @@ class TestBotCommands(unittest.TestCase):
 
     def test_prefix_commands_registered(self):
         """The primary command names resolve as text/prefix commands."""
-        for name in ("mvkroll", "plainroll", "anyroll", "setprefixes"):
+        for name in ("mvkroll", "plainroll", "anyroll", "average", "setprefixes"):
             with self.subTest(name=name):
                 self.assertIsNotNone(mvkdicebot.bot.get_command(name))
 
@@ -500,6 +526,8 @@ class TestBotCommands(unittest.TestCase):
             "justroll": "plainroll",
             "a": "anyroll",
             "rollany": "anyroll",
+            "mean": "average",
+            "m": "average",
             "esc": "escalation",
             "e": "escalation",
             "next": "nextround",
@@ -518,10 +546,12 @@ class TestBotCommands(unittest.TestCase):
             "mvkroll",
             "plainroll",
             "anyroll",
+            "average",
             "help",
             "r",
             "p",
             "a",
+            "m",
             "escalation",
             "esc",
             "nextround",

--- a/test.py
+++ b/test.py
@@ -418,6 +418,53 @@ class TestRoller(unittest.TestCase):
         self.assertTrue(any(line.startswith("Choose:") for line in lines))
 
 
+class TestAnyRoll(unittest.TestCase):
+    """Tests for anyroll: any die size, pools, modifiers, total (no special rules)."""
+
+    def test_parse_any_dice(self):
+        """Any die size is accepted, pools aggregate, result is largest-die-first."""
+        self.assertEqual(roller.parse_any_dice("3d3 d100 +17"), {100: 1, 3: 3})
+        self.assertEqual(roller.parse_any_dice("d7 d2 2d3"), {7: 1, 3: 2, 2: 1})
+        self.assertEqual(roller.parse_any_dice("d20 2d6"), {20: 1, 6: 2})
+        self.assertEqual(roller.parse_any_dice(""), {})
+
+    def test_parse_any_dice_bad_size(self):
+        """A die below 1 (e.g. d0) is rejected."""
+        with self.assertRaises(roller.RollError):
+            roller.parse_any_dice("d0")
+
+    def test_roll_any(self):
+        """roll_any rolls each size in range and only includes positive counts."""
+        out = roller.roll_any({100: 1, 3: 2, 8: 0}, random.Random(7))
+        self.assertEqual(set(out), {100, 3})  # d8 with count 0 omitted
+        self.assertEqual(len(out[3]), 2)
+        self.assertTrue(1 <= out[100][0] <= 100)
+        self.assertTrue(all(1 <= v <= 3 for v in out[3]))
+
+    def test_merge_any_keeps_prior_and_rolls_extra(self):
+        """Editing reuses prior dice and only rolls the newly-added ones."""
+        merged = roller.merge_any({3: [1, 2]}, {3: 3}, random.Random(0))
+        self.assertEqual(len(merged[3]), 3)
+        self.assertEqual(merged[3][:2], [1, 2])
+        self.assertTrue(1 <= merged[3][2] <= 3)
+        # Unchanged count reuses everything (no reroll).
+        self.assertEqual(roller.merge_any({100: [42]}, {100: 1})[100], [42])
+
+    def test_anyroll_output(self):
+        """anyroll formats like plainroll: -# Dice, optional -# Adjustment, **Total**."""
+        text, rolls = roller.anyroll("d100 +17", prior_rolls={100: [42]})
+        self.assertEqual(rolls, {100: [42]})
+        self.assertIn("-# Dice: 1d100[42]", text)
+        self.assertIn("-# Adjustment: 17", text)
+        self.assertIn("**Total: 59**", text)
+        # No modifier -> no Adjustment line; no crit/even/odd/escalation callouts.
+        text, _ = roller.anyroll("3d3", prior_rolls={3: [1, 2, 3]})
+        self.assertIn("-# Dice: 3d3[1, 2, 3]", text)
+        self.assertIn("**Total: 6**", text)
+        self.assertNotIn("Adjustment", text)
+        self.assertNotIn("Esc", text)
+
+
 class TestBotCommands(unittest.TestCase):
     """Test that the bot exposes both prefix and slash (app) commands.
 
@@ -440,7 +487,7 @@ class TestBotCommands(unittest.TestCase):
 
     def test_prefix_commands_registered(self):
         """The primary command names resolve as text/prefix commands."""
-        for name in ("mvkroll", "plainroll", "setprefixes"):
+        for name in ("mvkroll", "plainroll", "anyroll", "setprefixes"):
             with self.subTest(name=name):
                 self.assertIsNotNone(mvkdicebot.bot.get_command(name))
 
@@ -451,6 +498,8 @@ class TestBotCommands(unittest.TestCase):
             "roll": "mvkroll",
             "p": "plainroll",
             "justroll": "plainroll",
+            "a": "anyroll",
+            "rollany": "anyroll",
             "esc": "escalation",
             "e": "escalation",
             "next": "nextround",
@@ -468,9 +517,11 @@ class TestBotCommands(unittest.TestCase):
         for name in (
             "mvkroll",
             "plainroll",
+            "anyroll",
             "help",
             "r",
             "p",
+            "a",
             "escalation",
             "esc",
             "nextround",


### PR DESCRIPTION
Two new "Dice Rolling" commands.

## `anyroll` (aliases `a`, `rollany`; slash `/anyroll`, `/a`)
Like `plainroll` but with **no die-size restriction**, so `d100`, `3d3`, `d7`, `d2`, etc. all work. Rolls the pool, applies `+N`/`-N` modifiers, prints a total — no MvK/13th Age rules and none of the crit/fumble/even/odd callouts or escalation die. Output matches `plainroll` (`-# Dice:` / `-# Adjustment:` / `**Total:**`), sizes largest-first.

- `rollcommon.py`: `parse_any_dice`, `roll_any`, `merge_any` (edit-aware, size-agnostic). The standard d4–d20 path is untouched.

## `average` (aliases `mean`, `m`; slash `/average`, `/m`)
Totals the **average** result of a standard pool instead of rolling. Accepts the same dice as `plainroll` (d20–d4, rejects non-standard) plus `+N`/`-N` modifiers. Each die averages to half its max + 0.5 (d4 → 2.5, d20 → 10.5); shows `**Average: N**` (whole numbers drop the `.0`, halves shown as `.5`). Doesn't roll — grouped with the dice commands anyway. 13th Age uses this for damage and recovery rolls (never attack or skill checks).

## Notes
- Both are hybrid commands in the `Roll` cog, reusing `_run_text_roll`/`_run_slash_roll` (so editing a text roll behaves consistently).
- README updated. (CLAUDE.md updated locally; it's gitignored.)

## Tests
68 unit tests pass (added `TestAnyRoll` and `TestAverage` plus registration checks). pylint 10/10, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)