### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,6 +2,9 @@ name: Python Checks
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/freiheit/MvKDiceBot/security/code-scanning/4](https://github.com/freiheit/MvKDiceBot/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/python.yml` at the workflow root level (right after `on:` is a clean location). Since this workflow only needs to read repository contents for checkout and linting, set:

- `contents: read`

This is the smallest safe fix that preserves existing functionality and applies to all jobs in the workflow (currently only `build`). No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
