### PR TITLE
Tidy dice helpers, clearer invalid-die error, and a pool-size cap

### DIFF
--- a/mvkroller.py
+++ b/mvkroller.py
@@ -372,7 +372,7 @@ def average(dicestr: str, prior_rolls=None):  # pylint: disable=unused-argument
     mean = sum(count * (size + 1) / 2 for size, count in dicecounts.items())
     total = mean + add_amount
     # Each die's mean ends in .5, so a pool total is whole or .5; show it tidily.
-    shown = int(total) if total == int(total) else total
+    shown = int(total) if total.is_integer() else total
 
     pool = " ".join(
         f"{count}d{size}" for size, count in dicecounts.items() if count > 0

--- a/rollcommon.py
+++ b/rollcommon.py
@@ -55,6 +55,10 @@ class RollError(Exception):
         return self.message
 
 
+# Matches an optional count, optional spaces, 'd', and a die size (e.g. "3d6").
+_DICE_RE = re.compile(r"([0-9]*) *[dD]([0-9]+)")
+
+
 def parse_dice(dicestr: str):
     """Parses the dice string and returns a dictionary of dieSize->count"""
     # types of dice we're looking for:
@@ -67,10 +71,8 @@ def parse_dice(dicestr: str):
         4: 0,
     }
 
-    pattern_ndn = re.compile(r"([0-9]*) *[dD]([0-9]+)")
-
     try:
-        for count, size in re.findall(pattern_ndn, dicestr):
+        for count, size in re.findall(_DICE_RE, dicestr):
             logger.debug("Roll count=%s size=%s", count, size)
             size = int(size)
             if len(count) >= 1:
@@ -80,11 +82,26 @@ def parse_dice(dicestr: str):
             if size in dicecounts:
                 dicecounts[size] += count
             else:
-                raise RollError(f"Invalid dice size d{size}")
+                raise RollError(
+                    f"Invalid dice size d{size} (only d4, d6, d8, d10, d12, d20)."
+                )
+    except RollError:
+        raise  # keep the specific "Invalid dice size" message
     except Exception as exc:
         raise RollError("Exception while parsing dice.") from exc
 
     return dicecounts
+
+
+# Cap a pool so a roll's rendered dice list stays within Discord's message limit.
+MAX_DICE = 100
+
+
+def _check_pool_size(dicecounts):
+    """Raise if a pool would roll more than MAX_DICE dice (output too long)."""
+    total = sum(dicecounts.values())
+    if total > MAX_DICE:
+        raise RollError(f"Too many dice to roll ({total}); the max is {MAX_DICE}.")
 
 
 def _roll_one(size, rand_source):
@@ -105,6 +122,7 @@ def roll_dice(dicecounts, rand_source=None):
     dicerolls = _empty_dicerolls()
 
     try:
+        _check_pool_size(dicecounts)
         if rand_source is None:
             rand_source = random.Random()
 
@@ -113,6 +131,8 @@ def roll_dice(dicecounts, rand_source=None):
                 dicerolls[size] = [
                     _roll_one(size, rand_source) for idx in range(0, num)
                 ]
+    except RollError:
+        raise
     except Exception as exc:
         raise RollError("Exception while rolling dice.") from exc
 
@@ -131,6 +151,7 @@ def merge_rolls(prior, dicecounts, rand_source=None):
     dicerolls = _empty_dicerolls()
 
     try:
+        _check_pool_size(dicecounts)
         if rand_source is None:
             rand_source = random.Random()
 
@@ -140,6 +161,8 @@ def merge_rolls(prior, dicecounts, rand_source=None):
             kept = rand_source.sample(have, want) if want < len(have) else have
             extra = [_roll_one(size, rand_source) for _ in range(want - len(kept))]
             dicerolls[size] = kept + extra
+    except RollError:
+        raise
     except Exception as exc:
         raise RollError("Exception while merging dice rolls.") from exc
 
@@ -153,11 +176,9 @@ def parse_any_dice(dicestr: str):
     d4-d20 restriction. Returns ``{size: count}`` ordered largest-die-first;
     a size below 1 (e.g. ``d0``) raises ``RollError``.
     """
-    pattern_ndn = re.compile(r"([0-9]*) *[dD]([0-9]+)")
-
     counts = {}
     try:
-        for count, size in re.findall(pattern_ndn, dicestr):
+        for count, size in re.findall(_DICE_RE, dicestr):
             size = int(size)
             if size < 1:
                 raise RollError(f"Invalid dice size d{size}")
@@ -180,11 +201,14 @@ def roll_any(dicecounts, rand_source=None):
     if rand_source is None:
         rand_source = random.Random()
     try:
+        _check_pool_size(dicecounts)
         return {
             size: [_roll_one(size, rand_source) for _ in range(num)]
             for size, num in dicecounts.items()
             if num > 0
         }
+    except RollError:
+        raise
     except Exception as exc:
         raise RollError("Exception while rolling dice.") from exc
 
@@ -199,6 +223,7 @@ def merge_any(prior, dicecounts, rand_source=None):
     if rand_source is None:
         rand_source = random.Random()
     try:
+        _check_pool_size(dicecounts)
         merged = {}
         for size in sorted(set(prior) | set(dicecounts), reverse=True):
             want = dicecounts.get(size, 0)
@@ -210,6 +235,8 @@ def merge_any(prior, dicecounts, rand_source=None):
             if rolled:
                 merged[size] = rolled
         return merged
+    except RollError:
+        raise
     except Exception as exc:
         raise RollError("Exception while merging dice rolls.") from exc
 

--- a/test.py
+++ b/test.py
@@ -450,6 +450,13 @@ class TestAnyRoll(unittest.TestCase):
         # Unchanged count reuses everything (no reroll).
         self.assertEqual(roller.merge_any({100: [42]}, {100: 1})[100], [42])
 
+    def test_pool_size_cap(self):
+        """A pool larger than the cap is rejected (keeps output under the limit)."""
+        with self.assertRaises(roller.RollError):
+            roller.roll_any({6: 1000})
+        with self.assertRaises(roller.RollError):
+            roller.roll_dice({20: 1000})
+
     def test_anyroll_output(self):
         """anyroll formats like plainroll: -# Dice, optional -# Adjustment, **Total**."""
         text, rolls = roller.anyroll("d100 +17", prior_rolls={100: [42]})
@@ -486,9 +493,10 @@ class TestAverage(unittest.TestCase):
         self.assertIn("**Average: 14**", roller.average("d20 d6")[0])
 
     def test_average_rejects_nonstandard_dice(self):
-        """Like plainroll, only standard d4-d20 dice are accepted."""
-        with self.assertRaises(roller.RollError):
-            roller.average("d7")
+        """Non-standard dice are rejected with a message that names the size."""
+        with self.assertRaises(roller.RollError) as ctx:
+            roller.average("d100")
+        self.assertIn("d100", ctx.exception.getMessage())
 
 
 class TestBotCommands(unittest.TestCase):


### PR DESCRIPTION
Follow-up cleanup + small hardening after the code/simplify review of the `anyroll`/`average` work.

## Fixes
- **Clearer invalid-die error.** `parse_dice` now preserves its specific `Invalid dice size dN (only d4, d6, d8, d10, d12, d20).` message instead of re-wrapping it into the opaque `Exception while parsing dice.` So `average d100` / `plainroll d100` / `mvkroll 2d7` now say exactly what's wrong (previously a confusing generic error, especially next to `anyroll`, which accepts any size).
- **Pool-size cap.** Rolling a pool larger than `MAX_DICE` (100) now raises a friendly `Too many dice to roll (N); the max is 100.` instead of building a multi-thousand-character message that Discord rejects (`HTTPException`, 2000-char limit). Enforced in `roll_dice`/`roll_any`/`merge_rolls`/`merge_any` (the `RollError` contract is preserved). `average` is intentionally uncapped — it doesn't list dice, so its output stays short.

## Simplifications (from the review)
- Hoisted the duplicated `([0-9]*) *[dD]([0-9]+)` regex into a single module-level `_DICE_RE` shared by `parse_dice` and `parse_any_dice` (the new parser had added a second, per-call-compiled copy).
- `average`: `total == int(total)` → `total.is_integer()`.

Deliberately skipped (noted in the review): merging the `*_any` helpers into the test-locked standard helpers, extracting the per-roller output-assembly tail (kept explicit since these formats are tuned independently), and special-casing `average`'s empty-rolls return in shared cog infra.

## Tests
69 unit tests pass (added pool-cap and invalid-die-message tests). pylint 10/10, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)